### PR TITLE
More optimizations

### DIFF
--- a/src/main/java/tslib/model/arima/ARIMA.java
+++ b/src/main/java/tslib/model/arima/ARIMA.java
@@ -204,7 +204,46 @@ public class ARIMA {
     public List<PredictionInterval> forecastIntervals(int steps, double confidenceLevel) {
         requireFitted();
         List<Double> forecast = forecast(steps);
-        return ForecastIntervals.normalIntervals(forecast, innovationVariance, confidenceLevel, d > 0 || q > 0);
+        return ForecastIntervals.normalIntervals(forecast, computeStepVariances(steps), confidenceLevel);
+    }
+
+    /**
+     * Computes h-step forecast variances using the psi-weight (MA-infinity) representation.
+     * For ARMA(p,q): psi[0]=1, psi[h] = sum_i phi_i*psi[h-1-i] + theta[h-1].
+     * d-order integration is applied by cumulative summation.
+     * Var(e_h) = sigma^2 * sum_{j=0}^{h-1} psi[j]^2.
+     */
+    private List<Double> computeStepVariances(int steps) {
+        double[] psi = new double[steps];
+        if (steps > 0) {
+            psi[0] = 1.0;
+        }
+        for (int h = 1; h < steps; h++) {
+            double sum = 0.0;
+            for (int i = 0; i < p; i++) {
+                int idx = h - 1 - i;
+                if (idx >= 0) {
+                    sum += arCoefficients[i] * psi[idx];
+                }
+            }
+            if (h - 1 < q) {
+                sum += maCoefficients[h - 1];
+            }
+            psi[h] = sum;
+        }
+        for (int k = 0; k < d; k++) {
+            for (int h = 1; h < steps; h++) {
+                psi[h] += psi[h - 1];
+            }
+        }
+        List<Double> variances = new ArrayList<>(steps);
+        double cumPsiSq = 0.0;
+        double baseVar = Math.max(1e-12, innovationVariance);
+        for (int h = 0; h < steps; h++) {
+            cumPsiSq += psi[h] * psi[h];
+            variances.add(baseVar * cumPsiSq);
+        }
+        return variances;
     }
 
     public IntervalForecast forecastWithIntervals(int steps, double confidenceLevel) {

--- a/src/main/java/tslib/model/arima/SARIMA.java
+++ b/src/main/java/tslib/model/arima/SARIMA.java
@@ -244,8 +244,72 @@ public class SARIMA {
     public List<PredictionInterval> forecastIntervals(int steps, double confidenceLevel) {
         requireFitted();
         List<Double> forecast = forecast(steps);
-        boolean increasing = d > 0 || seasonalD > 0 || q > 0 || seasonalQ > 0;
-        return ForecastIntervals.normalIntervals(forecast, innovationVariance, confidenceLevel, increasing);
+        return ForecastIntervals.normalIntervals(forecast, computeStepVariances(steps), confidenceLevel);
+    }
+
+    /**
+     * Computes h-step forecast variances using the psi-weight (MA-infinity) representation.
+     * Handles arbitrary AR/MA lag sets from the combined non-seasonal and seasonal terms.
+     * Regular and seasonal differencing are integrated via cumulative summation.
+     */
+    private List<Double> computeStepVariances(int steps) {
+        // Build combined AR and MA coefficient arrays aligned with arLags/maLags
+        double[] allArCoeffs = new double[arLags.length];
+        System.arraycopy(arCoefficients, 0, allArCoeffs, 0, p);
+        System.arraycopy(seasonalArCoefficients, 0, allArCoeffs, p, seasonalP);
+
+        double[] allMaCoeffs = new double[maLags.length];
+        System.arraycopy(maCoefficients, 0, allMaCoeffs, 0, q);
+        System.arraycopy(seasonalMaCoefficients, 0, allMaCoeffs, q, seasonalQ);
+
+        int maxMaLag = 0;
+        for (int lag : maLags) {
+            maxMaLag = Math.max(maxMaLag, lag);
+        }
+        double[] maByLag = new double[maxMaLag + 1];
+        for (int i = 0; i < maLags.length; i++) {
+            maByLag[maLags[i]] = allMaCoeffs[i];
+        }
+
+        double[] psi = new double[steps];
+        if (steps > 0) {
+            psi[0] = 1.0;
+        }
+        for (int h = 1; h < steps; h++) {
+            double sum = 0.0;
+            for (int i = 0; i < arLags.length; i++) {
+                int lag = arLags[i];
+                if (h - lag >= 0) {
+                    sum += allArCoeffs[i] * psi[h - lag];
+                }
+            }
+            if (h <= maxMaLag) {
+                sum += maByLag[h];
+            }
+            psi[h] = sum;
+        }
+
+        // Regular differencing integration
+        for (int k = 0; k < d; k++) {
+            for (int h = 1; h < steps; h++) {
+                psi[h] += psi[h - 1];
+            }
+        }
+        // Seasonal differencing integration
+        for (int k = 0; k < seasonalD; k++) {
+            for (int h = seasonalPeriod; h < steps; h++) {
+                psi[h] += psi[h - seasonalPeriod];
+            }
+        }
+
+        List<Double> variances = new ArrayList<>(steps);
+        double cumPsiSq = 0.0;
+        double baseVar = Math.max(1e-12, innovationVariance);
+        for (int h = 0; h < steps; h++) {
+            cumPsiSq += psi[h] * psi[h];
+            variances.add(baseVar * cumPsiSq);
+        }
+        return variances;
     }
 
     public IntervalForecast forecastWithIntervals(int steps, double confidenceLevel) {

--- a/src/main/java/tslib/tests/AugmentedDickeyFuller.java
+++ b/src/main/java/tslib/tests/AugmentedDickeyFuller.java
@@ -13,8 +13,6 @@ public class AugmentedDickeyFuller {
     private double adfStat;
     private double[] zeroPaddedDiff;
 
-    private final double ADF_THRESHOLD = -3.45;
-
     public AugmentedDickeyFuller(List<Double> ts, int lag) {
         if (lag < 1) {
             throw new IllegalArgumentException("Lag must be >= 1");
@@ -69,7 +67,9 @@ public class AugmentedDickeyFuller {
 
         double t = beta[0] / sd[0];
         this.adfStat = t;
-        this.needsDiff = t > ADF_THRESHOLD;  // Fixed logic
+        // Sample-size-aware 5% critical value from MacKinnon / Dickey-Fuller response surface
+        double cv5pct = -3.41 + (-4.0 / n);
+        this.needsDiff = t > cv5pct;
     }
 
     private double[] diff(List<Double> x) {
@@ -116,6 +116,35 @@ public class AugmentedDickeyFuller {
             sequence[i - start] = i;
         }
         return sequence;
+    }
+
+    /**
+     * Returns an approximate p-value for the ADF test using the MacKinnon / Dickey-Fuller
+     * response surface (constant + trend model). Calibrated to the Dickey-Fuller (1979) table.
+     * Result is clamped to [0.01, 0.10]; values outside this range are reported at the boundary.
+     */
+    public double getPValue() {
+        int n = ts.size() - 1;
+        // Response surface: CV(alpha, n) = c_inf + c1/n
+        double[] levels = {0.01,   0.025,  0.05,   0.10};
+        double[] cInf   = {-3.96,  -3.68,  -3.41,  -3.12};
+        double[] c1     = {-8.0,   -6.0,   -4.0,   -3.0};
+
+        double[] cv = new double[levels.length];
+        for (int i = 0; i < levels.length; i++) {
+            cv[i] = cInf[i] + c1[i] / n;
+        }
+
+        if (adfStat <= cv[0]) return levels[0];
+        if (adfStat >= cv[levels.length - 1]) return levels[levels.length - 1];
+
+        for (int i = 0; i < levels.length - 1; i++) {
+            if (adfStat >= cv[i] && adfStat <= cv[i + 1]) {
+                double frac = (adfStat - cv[i]) / (cv[i + 1] - cv[i]);
+                return levels[i] + frac * (levels[i + 1] - levels[i]);
+            }
+        }
+        return levels[levels.length - 1];
     }
 
     public boolean isNeedsDiff() {

--- a/src/main/java/tslib/transform/Transform.java
+++ b/src/main/java/tslib/transform/Transform.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.math3.analysis.UnivariateFunction;
-import org.apache.commons.math3.optimization.GoalType;
-import org.apache.commons.math3.optimization.univariate.BrentOptimizer;
-import org.apache.commons.math3.optimization.univariate.UnivariateOptimizer;
+import org.apache.commons.math3.optim.MaxEval;
+import org.apache.commons.math3.optim.nonlinear.scalar.GoalType;
+import org.apache.commons.math3.optim.univariate.BrentOptimizer;
+import org.apache.commons.math3.optim.univariate.SearchInterval;
+import org.apache.commons.math3.optim.univariate.UnivariateObjectiveFunction;
 
 /**
  * Time series transformation utilities including log, root, and Box-Cox transformations.
@@ -64,25 +66,47 @@ public class Transform {
         return boxCox(data, boxCoxLambdaSearch(data));
     }
 
+    /**
+     * Inverse Box-Cox transform. Reverses boxCox(data, lambda).
+     * For lambda=0: x = exp(y). For lambda!=0: x = (y*lambda + 1)^(1/lambda).
+     */
+    public static List<Double> inverseBoxCox(List<Double> data, double lambda) {
+        if (data == null) {
+            throw new IllegalArgumentException("Data must not be null.");
+        }
+        List<Double> result = new ArrayList<>(data.size());
+        for (double y : data) {
+            if (lambda == 0) {
+                result.add(Math.exp(y));
+            } else {
+                double inner = y * lambda + 1.0;
+                if (inner <= 0) {
+                    throw new IllegalArgumentException(
+                            "Inverse Box-Cox undefined: y*lambda+1 must be > 0 for lambda != 0");
+                }
+                result.add(Math.pow(inner, 1.0 / lambda));
+            }
+        }
+        return result;
+    }
+
     public static double boxCoxLambdaSearch(List<Double> data) {
         return boxCoxLambdaSearch(data, -1, 2);
     }
 
     public static double boxCoxLambdaSearch(final List<Double> data, double lower, double upper) {
         validatePositive(data);
-
-        UnivariateOptimizer optimizer = new BrentOptimizer(1e-10, 1e-14);
+        BrentOptimizer optimizer = new BrentOptimizer(1e-10, 1e-14);
         return optimizer.optimize(
-                100,
-                new UnivariateFunction() {
+                new MaxEval(100),
+                new UnivariateObjectiveFunction(new UnivariateFunction() {
                     @Override
                     public double value(double lambda) {
                         return boxCoxNegLogLikelihood(data, lambda);
                     }
-                },
+                }),
                 GoalType.MINIMIZE,
-                lower,
-                upper
+                new SearchInterval(lower, upper)
         ).getPoint();
     }
 

--- a/src/test/java/tslib/transform/TransformTest.java
+++ b/src/test/java/tslib/transform/TransformTest.java
@@ -1,5 +1,6 @@
 package tslib.transform;
 
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -19,5 +20,43 @@ public class TransformTest {
     @Test(expected = IllegalArgumentException.class)
     public void logRejectsNonPositiveValues() {
         Transform.log(List.of(1.0, 0.0, 2.0));
+    }
+
+    @Test
+    public void inverseBoxCoxRoundTripLambdaZero() {
+        List<Double> original = Arrays.asList(1.0, 2.0, 4.0, 8.0);
+        List<Double> transformed = Transform.boxCox(original, 0.0);
+        List<Double> restored = Transform.inverseBoxCox(transformed, 0.0);
+        for (int i = 0; i < original.size(); i++) {
+            assertEquals(original.get(i), restored.get(i), 1e-9);
+        }
+    }
+
+    @Test
+    public void inverseBoxCoxRoundTripLambdaHalf() {
+        List<Double> original = Arrays.asList(1.0, 4.0, 9.0, 16.0);
+        double lambda = 0.5;
+        List<Double> transformed = Transform.boxCox(original, lambda);
+        List<Double> restored = Transform.inverseBoxCox(transformed, lambda);
+        for (int i = 0; i < original.size(); i++) {
+            assertEquals(original.get(i), restored.get(i), 1e-9);
+        }
+    }
+
+    @Test
+    public void inverseBoxCoxRoundTripLambdaOne() {
+        List<Double> original = Arrays.asList(2.0, 5.0, 10.0);
+        double lambda = 1.0;
+        List<Double> transformed = Transform.boxCox(original, lambda);
+        List<Double> restored = Transform.inverseBoxCox(transformed, lambda);
+        for (int i = 0; i < original.size(); i++) {
+            assertEquals(original.get(i), restored.get(i), 1e-9);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void inverseBoxCoxThrowsWhenInnerNonPositive() {
+        // lambda=2, y=-1: y*lambda+1 = -1*2+1 = -1 <= 0
+        Transform.inverseBoxCox(Arrays.asList(-1.0), 2.0);
     }
 }

--- a/src/test/java/tslib/tstest/AugmentedDickeyFullerTest.java
+++ b/src/test/java/tslib/tstest/AugmentedDickeyFullerTest.java
@@ -33,4 +33,30 @@ public class AugmentedDickeyFullerTest {
         System.out.println("ADF stat (trend + outlier): " + adf.getAdfStat());
         assertFalse("Expected non-stationary series with outlier", adf.isNeedsDiff());
     }
+
+    @Test
+    public void testGetPValueInRange() {
+        ArrayList<Double> x = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            x.add(i * 1.5);
+        }
+        AugmentedDickeyFuller adf = new AugmentedDickeyFuller(x);
+        double pValue = adf.getPValue();
+        assertTrue("p-value must be in [0.01, 0.10]", pValue >= 0.01 && pValue <= 0.10);
+    }
+
+    @Test
+    public void testGetPValueStationarySeries() {
+        // Stationary: white noise should have a very negative ADF stat → p-value at minimum (0.01)
+        ArrayList<Double> x = new ArrayList<>();
+        java.util.Random rng = new java.util.Random(42);
+        for (int i = 0; i < 200; i++) {
+            x.add(rng.nextGaussian());
+        }
+        AugmentedDickeyFuller adf = new AugmentedDickeyFuller(x);
+        // White noise is stationary; ADF stat should be very negative
+        assertTrue("Stationary series should have ADF stat < -3.0", adf.getAdfStat() < -3.0);
+        assertEquals("p-value should be at lower boundary (0.01) for stationary white noise",
+                0.01, adf.getPValue(), 1e-9);
+    }
 }


### PR DESCRIPTION
* WeightedMovingAverage: Already fully implemented (the explora…tion agent was mistaken). All 20 pre-written tests pass.

* inverseBoxCox: Added Transform.inverseBoxCox(data, lambda) to Transform.java. For λ=0: exp(y); for λ≠0: (y·λ+1)^(1/λ). Also fixed the deprecated optimization.univariate.BrentOptimizer → new optim.univariate.BrentOptimizer API. Added 4 new tests including round-trip verification.

* ARIMA/SARIMA prediction intervals: Replaced the 1 + 0.25*i heuristic with proper ψ-weight (MA∞ representation) variance computation in both ARIMA.java and SARIMA.java. The ψ-weight recursion (ψ_h = Σ φᵢ·ψ_{h-i} + θ_h) is applied, then d-order integration via cumulative summation (and seasonal period for SARIMA). Var(e_h) = σ² · Σⱼ₌₀ʰ⁻¹ ψⱼ². For a random walk (ARIMA(0,1,0)) this correctly gives h·σ²; for stationary AR(1) it correctly converges to σ²/(1-φ²).

* ADF p-values: Added getPValue() to AugmentedDickeyFuller using the MacKinnon/Dickey-Fuller response surface at 4 quantile levels (1%, 2.5%, 5%, 10%) with linear interpolation. Updated needsDiff to use a sample-size-aware critical value (-3.41 + (-4.0/n)) instead of the hardcoded -3.45. At n=100 this evaluates to exactly -3.45, so existing tests are unaffected.