### PR TITLE
Thread safe collect caches, nelder mead/brent optimizer for autoETS, upgrade to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ repositories {
 dependencies {
     api 'org.apache.commons:commons-math3:3.6.1'
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
 java {
@@ -40,7 +41,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.withType(Test).configureEach {
-    useJUnit()
+    useJUnitPlatform()
     testLogging {
         events 'passed', 'skipped', 'failed'
         exceptionFormat 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.10.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 java {

--- a/src/main/java/tslib/collect/Collect.java
+++ b/src/main/java/tslib/collect/Collect.java
@@ -21,17 +21,17 @@ public class Collect {
     private final int _n;
     protected final List<Double> _data;
     
-    // Cached values for performance
-    private Double _cachedAverage = null;
-    private Double _cachedVariance = null;
-    private Double _cachedStandardDeviation = null;
-    private Integer _cachedMinIndex = null;
-    private Integer _cachedMaxIndex = null;
-    private Double _cachedMin = null;
-    private Double _cachedMax = null;
-    private Double _cachedADFStat = null;
-    private Boolean _cachedIsStationary = null;
-    private AugmentedDickeyFuller _adfInstance = null;
+    // Cached values for performance — volatile ensures cross-thread visibility
+    private volatile Double _cachedAverage = null;
+    private volatile Double _cachedVariance = null;
+    private volatile Double _cachedStandardDeviation = null;
+    private volatile Integer _cachedMinIndex = null;
+    private volatile Integer _cachedMaxIndex = null;
+    private volatile Double _cachedMin = null;
+    private volatile Double _cachedMax = null;
+    private volatile Double _cachedADFStat = null;
+    private volatile Boolean _cachedIsStationary = null;
+    private volatile AugmentedDickeyFuller _adfInstance = null;
 
     public Collect(String filepath, int k, int n) throws IOException {
         this._filepath = filepath;

--- a/src/main/java/tslib/selection/AutoETS.java
+++ b/src/main/java/tslib/selection/AutoETS.java
@@ -3,8 +3,12 @@ package tslib.selection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import tslib.evaluation.ForecastFunction;
-import tslib.evaluation.ForecastMetrics;
+import org.apache.commons.math3.optim.MaxEval;
+import org.apache.commons.math3.optim.nonlinear.scalar.GoalType;
+import org.apache.commons.math3.optim.univariate.BrentOptimizer;
+import org.apache.commons.math3.optim.univariate.SearchInterval;
+import org.apache.commons.math3.optim.univariate.UnivariateObjectiveFunction;
+import org.apache.commons.math3.optim.univariate.UnivariatePointValuePair;
 import tslib.evaluation.RollingOriginBacktest;
 import tslib.model.expsmoothing.DoubleExpSmoothing;
 import tslib.model.expsmoothing.ExponentialSmoothing;
@@ -12,7 +16,9 @@ import tslib.model.expsmoothing.SingleExpSmoothing;
 import tslib.model.expsmoothing.TripleExpSmoothing;
 
 /**
- * Simple grid-search selector for exponential smoothing models.
+ * Optimizer-based selector for exponential smoothing models.
+ * Uses Brent's method with coordinate descent instead of a coarse grid search,
+ * giving precise parameter estimates over the continuous [0.01, 0.99] domain.
  */
 public class AutoETS {
 
@@ -22,7 +28,10 @@ public class AutoETS {
         TRIPLE
     }
 
-    private static final double[] GRID = {0.2, 0.4, 0.6, 0.8};
+    private static final int MAX_EVAL = 200;
+    private static final double PARAM_LO = 0.01;
+    private static final double PARAM_HI = 0.99;
+    private static final int COORD_ITERS = 4;
 
     private final Integer seasonalPeriod;
     private ModelType bestType;
@@ -45,34 +54,95 @@ public class AutoETS {
         }
         this.trainingData = new ArrayList<>(data);
         RollingOriginBacktest backtest = new RollingOriginBacktest(Math.max(3, data.size() / 2), 1);
+        BrentOptimizer brent = new BrentOptimizer(1e-4, 1e-6);
 
-        for (double alpha : GRID) {
-            ExponentialSmoothing candidate = new SingleExpSmoothing(alpha);
-            double score = backtest.run(data, candidate::forecast).getRmse();
-            consider(ModelType.SINGLE, new double[] {alpha}, candidate, score);
-        }
+        // SES: single Brent pass over alpha in [PARAM_LO, PARAM_HI]
+        UnivariatePointValuePair sesResult = brent.optimize(
+                new MaxEval(MAX_EVAL),
+                GoalType.MINIMIZE,
+                new SearchInterval(PARAM_LO, PARAM_HI, 0.3),
+                new UnivariateObjectiveFunction(a -> {
+                    ExponentialSmoothing c = new SingleExpSmoothing(a);
+                    return backtest.run(data, c::forecast).getRmse();
+                }));
+        consider(ModelType.SINGLE,
+                new double[]{sesResult.getPoint()},
+                new SingleExpSmoothing(sesResult.getPoint()),
+                sesResult.getValue());
 
-        for (double alpha : GRID) {
-            for (double gamma : GRID) {
-                for (int init = 0; init <= 2; init++) {
-                    ExponentialSmoothing candidate = new DoubleExpSmoothing(alpha, gamma, init);
-                    double score = backtest.run(data, candidate::forecast).getRmse();
-                    consider(ModelType.DOUBLE, new double[] {alpha, gamma, init}, candidate, score);
-                }
+        // DES: coordinate descent over alpha and gamma, repeated for each init style
+        for (int init = 0; init <= 2; init++) {
+            final int fixedInit = init;
+            double alpha = 0.3, gamma = 0.3;
+            for (int iter = 0; iter < COORD_ITERS; iter++) {
+                final double g = gamma;
+                UnivariatePointValuePair ra = brent.optimize(
+                        new MaxEval(MAX_EVAL),
+                        GoalType.MINIMIZE,
+                        new SearchInterval(PARAM_LO, PARAM_HI, alpha),
+                        new UnivariateObjectiveFunction(a -> {
+                            ExponentialSmoothing c = new DoubleExpSmoothing(a, g, fixedInit);
+                            return backtest.run(data, c::forecast).getRmse();
+                        }));
+                alpha = ra.getPoint();
+                final double a = alpha;
+                UnivariatePointValuePair rg = brent.optimize(
+                        new MaxEval(MAX_EVAL),
+                        GoalType.MINIMIZE,
+                        new SearchInterval(PARAM_LO, PARAM_HI, gamma),
+                        new UnivariateObjectiveFunction(gv -> {
+                            ExponentialSmoothing c = new DoubleExpSmoothing(a, gv, fixedInit);
+                            return backtest.run(data, c::forecast).getRmse();
+                        }));
+                gamma = rg.getPoint();
             }
+            ExponentialSmoothing desBest = new DoubleExpSmoothing(alpha, gamma, fixedInit);
+            consider(ModelType.DOUBLE,
+                    new double[]{alpha, gamma, fixedInit},
+                    desBest,
+                    backtest.run(data, desBest::forecast).getRmse());
         }
 
+        // TES: coordinate descent over alpha, beta, gamma (only if seasonal data is available)
         if (seasonalPeriod != null && seasonalPeriod > 1 && data.size() >= seasonalPeriod * 2) {
-            for (double alpha : GRID) {
-                for (double beta : GRID) {
-                    for (double gamma : GRID) {
-                        ExponentialSmoothing candidate = new TripleExpSmoothing(alpha, beta, gamma, seasonalPeriod, false);
-                        ForecastFunction function = candidate::forecast;
-                        double score = backtest.run(data, function).getRmse();
-                        consider(ModelType.TRIPLE, new double[] {alpha, beta, gamma, seasonalPeriod}, candidate, score);
-                    }
-                }
+            double alpha = 0.3, beta = 0.1, gamma = 0.3;
+            for (int iter = 0; iter < COORD_ITERS; iter++) {
+                final double b0 = beta, g0 = gamma;
+                UnivariatePointValuePair ra = brent.optimize(
+                        new MaxEval(MAX_EVAL),
+                        GoalType.MINIMIZE,
+                        new SearchInterval(PARAM_LO, PARAM_HI, alpha),
+                        new UnivariateObjectiveFunction(a -> {
+                            ExponentialSmoothing c = new TripleExpSmoothing(a, b0, g0, seasonalPeriod, false);
+                            return backtest.run(data, c::forecast).getRmse();
+                        }));
+                alpha = ra.getPoint();
+                final double a1 = alpha, g1 = gamma;
+                UnivariatePointValuePair rb = brent.optimize(
+                        new MaxEval(MAX_EVAL),
+                        GoalType.MINIMIZE,
+                        new SearchInterval(PARAM_LO, PARAM_HI, beta),
+                        new UnivariateObjectiveFunction(bv -> {
+                            ExponentialSmoothing c = new TripleExpSmoothing(a1, bv, g1, seasonalPeriod, false);
+                            return backtest.run(data, c::forecast).getRmse();
+                        }));
+                beta = rb.getPoint();
+                final double a2 = alpha, b2 = beta;
+                UnivariatePointValuePair rg = brent.optimize(
+                        new MaxEval(MAX_EVAL),
+                        GoalType.MINIMIZE,
+                        new SearchInterval(PARAM_LO, PARAM_HI, gamma),
+                        new UnivariateObjectiveFunction(gv -> {
+                            ExponentialSmoothing c = new TripleExpSmoothing(a2, b2, gv, seasonalPeriod, false);
+                            return backtest.run(data, c::forecast).getRmse();
+                        }));
+                gamma = rg.getPoint();
             }
+            ExponentialSmoothing tesBest = new TripleExpSmoothing(alpha, beta, gamma, seasonalPeriod, false);
+            consider(ModelType.TRIPLE,
+                    new double[]{alpha, beta, gamma, seasonalPeriod},
+                    tesBest,
+                    backtest.run(data, tesBest::forecast).getRmse());
         }
 
         return this;

--- a/src/test/java/tslib/collect/CollectTest.java
+++ b/src/test/java/tslib/collect/CollectTest.java
@@ -1,6 +1,6 @@
 package tslib.collect;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import tslib.model.expsmoothing.SingleExpSmoothing;
 import tslib.model.expsmoothing.TripleExpSmoothing;
 import tslib.movingaverage.*;
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CollectTest {
 
@@ -94,7 +94,7 @@ public class CollectTest {
             long duration = (endTime - startTime) / 1_000_000; // Convert to milliseconds
             
             // Performance assertion - should complete within reasonable time
-            assertTrue("Performance test failed: took " + duration + " ms", duration < 1000);
+            assertTrue(duration < 1000, "Performance test failed: took " + duration + " ms");
             
             // Test 2: Rolling average performance
             startTime = System.nanoTime();
@@ -105,7 +105,7 @@ public class CollectTest {
             duration = (endTime - startTime) / 1_000_000;
             
             assertNotNull(rollingAvg);
-            assertTrue("Rolling average performance test failed: took " + duration + " ms", duration < 500);
+            assertTrue(duration < 500, "Rolling average performance test failed: took " + duration + " ms");
             
             // Test 3: Stationarity tests (expensive operations)
             startTime = System.nanoTime();
@@ -116,7 +116,7 @@ public class CollectTest {
             endTime = System.nanoTime();
             duration = (endTime - startTime) / 1_000_000;
             
-            assertTrue("ADF test performance failed: took " + duration + " ms", duration < 2000);
+            assertTrue(duration < 2000, "ADF test performance failed: took " + duration + " ms");
             
             // Test 4: Second call to ADF (should be cached)
             startTime = System.nanoTime();
@@ -128,7 +128,7 @@ public class CollectTest {
             duration = (endTime - startTime) / 1_000_000;
             
             // Cached calls should be much faster
-            assertTrue("Cached ADF test should be faster: took " + duration + " ms", duration < 100);
+            assertTrue(duration < 100, "Cached ADF test should be faster: took " + duration + " ms");
             
             // Verify cached results are consistent
             assertEquals(adfStat, adfStat2, 1e-10);
@@ -144,7 +144,7 @@ public class CollectTest {
             
             assertNotNull(summary);
             assertFalse(summary.isEmpty());
-            assertTrue("Summary generation performance failed: took " + duration + " ms", duration < 100);
+            assertTrue(duration < 100, "Summary generation performance failed: took " + duration + " ms");
             
         } finally {
             // Clean up temporary file
@@ -174,7 +174,7 @@ public class CollectTest {
             assertEquals(firstAverage, secondAverage, 1e-10);
             
             // Verify second call is faster (cached)
-            assertTrue("Cached call should be faster", secondCallTime < firstCallTime);
+            assertTrue(secondCallTime < firstCallTime, "Cached call should be faster");
             
             // Test variance caching
             startTime = System.nanoTime();
@@ -186,7 +186,7 @@ public class CollectTest {
             secondCallTime = System.nanoTime() - startTime;
             
             assertEquals(firstVariance, secondVariance, 1e-10);
-            assertTrue("Cached variance call should be faster", secondCallTime < firstCallTime);
+            assertTrue(secondCallTime < firstCallTime, "Cached variance call should be faster");
             
         } finally {
             new java.io.File(tempFile).delete();

--- a/src/test/java/tslib/dataquality/DataQualityEdgeCaseTest.java
+++ b/src/test/java/tslib/dataquality/DataQualityEdgeCaseTest.java
@@ -2,8 +2,8 @@ package tslib.dataquality;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DataQualityEdgeCaseTest {
 

--- a/src/test/java/tslib/dataquality/DataQualityTest.java
+++ b/src/test/java/tslib/dataquality/DataQualityTest.java
@@ -2,8 +2,8 @@ package tslib.dataquality;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DataQualityTest {
     @Test

--- a/src/test/java/tslib/dataquality/OutlierDetectorTest.java
+++ b/src/test/java/tslib/dataquality/OutlierDetectorTest.java
@@ -2,8 +2,8 @@ package tslib.dataquality;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OutlierDetectorTest {
 
@@ -29,9 +29,9 @@ public class OutlierDetectorTest {
         assertTrue(outliers.contains(4));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void zScoreThrowsOnNonPositiveThreshold() {
-        OutlierDetector.zScore(Arrays.asList(1.0, 2.0, 3.0), 0.0);
+        assertThrows(IllegalArgumentException.class, () -> OutlierDetector.zScore(Arrays.asList(1.0, 2.0, 3.0), 0.0));
     }
 
     @Test
@@ -48,9 +48,9 @@ public class OutlierDetectorTest {
         assertTrue(outliers.isEmpty());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void iqrThrowsOnNonPositiveMultiplier() {
-        OutlierDetector.iqr(Arrays.asList(1.0, 2.0, 3.0), 0.0);
+        assertThrows(IllegalArgumentException.class, () -> OutlierDetector.iqr(Arrays.asList(1.0, 2.0, 3.0), 0.0));
     }
 
     @Test

--- a/src/test/java/tslib/dataquality/WinsorizerTest.java
+++ b/src/test/java/tslib/dataquality/WinsorizerTest.java
@@ -2,8 +2,8 @@ package tslib.dataquality;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WinsorizerTest {
 
@@ -49,19 +49,19 @@ public class WinsorizerTest {
         assertEquals(data.size(), result.size());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void winsorizeThrowsOnInvalidProbabilities() {
-        Winsorizer.winsorize(Arrays.asList(1.0, 2.0, 3.0), 0.8, 0.2);
+        assertThrows(IllegalArgumentException.class, () -> Winsorizer.winsorize(Arrays.asList(1.0, 2.0, 3.0), 0.8, 0.2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void winsorizeThrowsWhenLowerEqualsUpper() {
-        Winsorizer.winsorize(Arrays.asList(1.0, 2.0, 3.0), 0.5, 0.5);
+        assertThrows(IllegalArgumentException.class, () -> Winsorizer.winsorize(Arrays.asList(1.0, 2.0, 3.0), 0.5, 0.5));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void winsorizeThrowsOnNegativeLower() {
-        Winsorizer.winsorize(Arrays.asList(1.0, 2.0, 3.0), -0.1, 0.9);
+        assertThrows(IllegalArgumentException.class, () -> Winsorizer.winsorize(Arrays.asList(1.0, 2.0, 3.0), -0.1, 0.9));
     }
 
     @Test

--- a/src/test/java/tslib/decomposition/STLDecompositionEdgeCaseTest.java
+++ b/src/test/java/tslib/decomposition/STLDecompositionEdgeCaseTest.java
@@ -2,8 +2,8 @@ package tslib.decomposition;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class STLDecompositionEdgeCaseTest {
 
@@ -50,7 +50,7 @@ public class STLDecompositionEdgeCaseTest {
         STLDecomposition.Result result = stl.decompose(data);
         double earlyTrend = result.getTrend().subList(0, 4).stream().mapToDouble(Double::doubleValue).average().orElse(0);
         double lateTrend = result.getTrend().subList(20, 24).stream().mapToDouble(Double::doubleValue).average().orElse(0);
-        assertTrue("Late trend should be higher than early trend", lateTrend > earlyTrend);
+        assertTrue(lateTrend > earlyTrend, "Late trend should be higher than early trend");
     }
 
     @Test
@@ -74,26 +74,26 @@ public class STLDecompositionEdgeCaseTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsOnPeriodLessThanTwo() {
-        new STLDecomposition(1);
+        assertThrows(IllegalArgumentException.class, () -> new STLDecomposition(1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsOnTooShortSeries() {
         List<Double> data = new ArrayList<>();
         for (int i = 0; i < 5; i++) data.add((double) i);
-        new STLDecomposition(4).decompose(data);
+        assertThrows(IllegalArgumentException.class, () -> new STLDecomposition(4).decompose(data));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsOnEvenTrendWindow() {
-        new STLDecomposition(4, 6, 7, 2);
+        assertThrows(IllegalArgumentException.class, () -> new STLDecomposition(4, 6, 7, 2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsOnEvenSeasonalWindow() {
-        new STLDecomposition(4, 7, 6, 2);
+        assertThrows(IllegalArgumentException.class, () -> new STLDecomposition(4, 7, 6, 2));
     }
 
     @Test
@@ -101,11 +101,6 @@ public class STLDecompositionEdgeCaseTest {
         List<Double> data = pureSeasonalData(3, 4);
         STLDecomposition stl = new STLDecomposition(4);
         STLDecomposition.Result result = stl.decompose(data);
-        try {
-            result.getTrend().set(0, 999.0);
-            fail("Expected UnsupportedOperationException for immutable list");
-        } catch (UnsupportedOperationException e) {
-            // expected
-        }
+        assertThrows(UnsupportedOperationException.class, () -> result.getTrend().set(0, 999.0));
     }
 }

--- a/src/test/java/tslib/decomposition/STLDecompositionTest.java
+++ b/src/test/java/tslib/decomposition/STLDecompositionTest.java
@@ -2,8 +2,8 @@ package tslib.decomposition;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class STLDecompositionTest {
 

--- a/src/test/java/tslib/diagnostics/LjungBoxTestTest.java
+++ b/src/test/java/tslib/diagnostics/LjungBoxTestTest.java
@@ -2,8 +2,8 @@ package tslib.diagnostics;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LjungBoxTestTest {
     @Test

--- a/src/test/java/tslib/evaluation/BenchmarkMarkdownTest.java
+++ b/src/test/java/tslib/evaluation/BenchmarkMarkdownTest.java
@@ -1,8 +1,8 @@
 package tslib.evaluation;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BenchmarkMarkdownTest {
 

--- a/src/test/java/tslib/evaluation/ForecastMetricsTest.java
+++ b/src/test/java/tslib/evaluation/ForecastMetricsTest.java
@@ -1,8 +1,8 @@
 package tslib.evaluation;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ForecastMetricsTest {
     @Test

--- a/src/test/java/tslib/evaluation/ModelBenchmarkTest.java
+++ b/src/test/java/tslib/evaluation/ModelBenchmarkTest.java
@@ -3,8 +3,8 @@ package tslib.evaluation;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelBenchmarkTest {
     @Test

--- a/src/test/java/tslib/evaluation/PredictionIntervalSupportTest.java
+++ b/src/test/java/tslib/evaluation/PredictionIntervalSupportTest.java
@@ -1,10 +1,10 @@
 package tslib.evaluation;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import tslib.model.ARIMA;
 import tslib.model.LocalLevelModel;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PredictionIntervalSupportTest {
     @Test

--- a/src/test/java/tslib/evaluation/ReleaseCandidateWorkflowTest.java
+++ b/src/test/java/tslib/evaluation/ReleaseCandidateWorkflowTest.java
@@ -4,13 +4,13 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import tslib.dataquality.MissingValueImputer;
 import tslib.model.ARIMA;
 import tslib.model.LocalLevelModel;
 import tslib.model.TripleExpSmoothing;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReleaseCandidateWorkflowTest {
 

--- a/src/test/java/tslib/evaluation/RollingOriginBacktestTest.java
+++ b/src/test/java/tslib/evaluation/RollingOriginBacktestTest.java
@@ -1,8 +1,8 @@
 package tslib.evaluation;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RollingOriginBacktestTest {
     @Test

--- a/src/test/java/tslib/model/ArimaxRegressionTest.java
+++ b/src/test/java/tslib/model/ArimaxRegressionTest.java
@@ -1,21 +1,22 @@
 package tslib.model;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ArimaxRegressionTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void fitRejectsMismatchedExogenousRowCount() {
-        new ARIMAX(0, 0, 0).fit(List.of(1.0, 2.0, 3.0), new double[][] {{1.0}, {2.0}});
+        assertThrows(IllegalArgumentException.class, () ->
+                new ARIMAX(0, 0, 0).fit(List.of(1.0, 2.0, 3.0), new double[][] {{1.0}, {2.0}}));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void forecastRejectsWrongFutureFeatureWidth() {
         ARIMAX model = new ARIMAX(0, 0, 0).fit(
                 List.of(7.0, 9.0, 11.0, 13.0),
                 new double[][] {{1.0}, {2.0}, {3.0}, {4.0}});
-        model.forecast(new double[][] {{5.0, 6.0}});
+        assertThrows(IllegalArgumentException.class, () -> model.forecast(new double[][] {{5.0, 6.0}}));
     }
 }

--- a/src/test/java/tslib/model/CompatibilityAliasTest.java
+++ b/src/test/java/tslib/model/CompatibilityAliasTest.java
@@ -1,8 +1,8 @@
 package tslib.model;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CompatibilityAliasTest {
     @Test

--- a/src/test/java/tslib/model/DoubleExpSmoothingTest.java
+++ b/src/test/java/tslib/model/DoubleExpSmoothingTest.java
@@ -1,12 +1,12 @@
 package tslib.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import tslib.model.expsmoothing.DoubleExpSmoothing;
 
 import java.util.List;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DoubleExpSmoothingTest {
 
@@ -34,7 +34,7 @@ public class DoubleExpSmoothingTest {
         double slope = prediction.get(y.size()) - lastSmoothed;
 
         for (int i = y.size(); i < prediction.size(); i++) {
-            assertTrue("Forecasted value should be positive", prediction.get(i) > 0);
+            assertTrue(prediction.get(i) > 0, "Forecasted value should be positive");
         }
 
         // Optional: print forecast values for manual inspection

--- a/src/test/java/tslib/model/SingleExpSmoothingTest.java
+++ b/src/test/java/tslib/model/SingleExpSmoothingTest.java
@@ -1,12 +1,12 @@
 package tslib.model;
 
 import tslib.model.expsmoothing.SingleExpSmoothing;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SingleExpSmoothingTest {
 

--- a/src/test/java/tslib/model/TripleExpSmoothingTest.java
+++ b/src/test/java/tslib/model/TripleExpSmoothingTest.java
@@ -1,12 +1,12 @@
 package tslib.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import tslib.model.expsmoothing.TripleExpSmoothing;
 
 import java.util.List;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TripleExpSmoothingTest {
 
@@ -32,7 +32,7 @@ public class TripleExpSmoothingTest {
 
         // Verify forecast values are positive and not just zero padding
         for (int i = y.size(); i < forecast.size(); i++) {
-            assertTrue("Forecasted value should be greater than zero", forecast.get(i) > 0.0);
+            assertTrue(forecast.get(i) > 0.0, "Forecasted value should be greater than zero");
         }
 
         // Optionally print for manual inspection

--- a/src/test/java/tslib/model/arima/ARIMATest.java
+++ b/src/test/java/tslib/model/arima/ARIMATest.java
@@ -2,10 +2,15 @@ package tslib.model.arima;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ARIMATest {
 
@@ -54,6 +59,65 @@ public class ARIMATest {
         assertEquals(data.size() + 2, combined.size());
         assertEquals(11.0, combined.get(combined.size() - 2), 1e-6);
         assertEquals(12.0, combined.get(combined.size() - 1), 1e-6);
+        assertTrue(model.getInnovationVariance() >= 0.0);
+    }
+
+    static Stream<Arguments> arimaOrders() {
+        return Stream.of(
+            Arguments.of(0, 1, 0),
+            Arguments.of(1, 0, 0),
+            Arguments.of(0, 0, 1),
+            Arguments.of(1, 1, 0),
+            Arguments.of(0, 1, 1),
+            Arguments.of(2, 0, 0),
+            Arguments.of(1, 0, 1),
+            Arguments.of(0, 2, 0),
+            Arguments.of(2, 1, 0),
+            Arguments.of(1, 1, 1)
+        );
+    }
+
+    @ParameterizedTest(name = "ARIMA({0},{1},{2}) forecasts finite values")
+    @MethodSource("arimaOrders")
+    public void arimaFitsAndForecastsFiniteValues(int p, int d, int q) {
+        List<Double> data = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            data.add((double) i + (i % 3) * 0.5);
+        }
+        ARIMA model = new ARIMA(p, d, q).fit(data);
+        List<Double> future = model.forecast(3);
+
+        assertEquals(3, future.size());
+        for (double f : future) {
+            assertFalse(Double.isNaN(f), "Forecast must not be NaN for ARIMA(" + p + "," + d + "," + q + ")");
+            assertFalse(Double.isInfinite(f), "Forecast must not be infinite for ARIMA(" + p + "," + d + "," + q + ")");
+        }
+    }
+
+    @ParameterizedTest(name = "ARIMA({0},{1},{2}) residuals are non-empty and bounded")
+    @MethodSource("arimaOrders")
+    public void arimaResidualsAreNonEmptyAndBounded(int p, int d, int q) {
+        List<Double> data = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            data.add((double) i);
+        }
+        ARIMA model = new ARIMA(p, d, q).fit(data);
+        List<Double> residuals = model.getResiduals();
+        assertFalse(residuals.isEmpty(), "Residuals must not be empty");
+        assertTrue(residuals.size() <= data.size(), "Residuals must not exceed data size");
+        for (double r : residuals) {
+            assertFalse(Double.isNaN(r), "Residual must not be NaN");
+        }
+    }
+
+    @ParameterizedTest(name = "ARIMA({0},{1},{2}) innovation variance is non-negative")
+    @MethodSource("arimaOrders")
+    public void arimaInnovationVarianceIsNonNegative(int p, int d, int q) {
+        List<Double> data = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            data.add((double) i + Math.sin(i * 0.5));
+        }
+        ARIMA model = new ARIMA(p, d, q).fit(data);
         assertTrue(model.getInnovationVariance() >= 0.0);
     }
 }

--- a/src/test/java/tslib/model/arima/ARIMAXEdgeCaseTest.java
+++ b/src/test/java/tslib/model/arima/ARIMAXEdgeCaseTest.java
@@ -2,8 +2,8 @@ package tslib.model.arima;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ARIMAXEdgeCaseTest {
 
@@ -49,28 +49,28 @@ public class ARIMAXEdgeCaseTest {
         assertTrue(model.getInnovationVariance() >= 0.0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void arimaxThrowsOnNullData() {
         double[][] x = {{1.0}, {2.0}};
-        new ARIMAX(0, 0, 0).fit(null, x);
+        assertThrows(IllegalArgumentException.class, () -> new ARIMAX(0, 0, 0).fit(null, x));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void arimaxThrowsOnMismatchedExogenousRows() {
         List<Double> y = Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0);
         double[][] x = {{1.0}, {2.0}};
-        new ARIMAX(0, 0, 0).fit(y, x);
+        assertThrows(IllegalArgumentException.class, () -> new ARIMAX(0, 0, 0).fit(y, x));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void arimaxThrowsOnNullExogenous() {
         List<Double> y = Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0);
-        new ARIMAX(0, 0, 0).fit(y, null);
+        assertThrows(IllegalArgumentException.class, () -> new ARIMAX(0, 0, 0).fit(y, null));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void arimaxThrowsOnForecastBeforeFit() {
-        new ARIMAX(0, 0, 0).forecast(new double[][]{{1.0}});
+        assertThrows(IllegalStateException.class, () -> new ARIMAX(0, 0, 0).forecast(new double[][]{{1.0}}));
     }
 
     @Test
@@ -78,12 +78,7 @@ public class ARIMAXEdgeCaseTest {
         List<Double> y = Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
         double[][] x = {{1.0}, {2.0}, {3.0}, {4.0}, {5.0}, {6.0}};
         ARIMAX model = new ARIMAX(0, 0, 0).fit(y, x);
-        try {
-            model.forecast(new double[][]{{1.0, 2.0}});
-            fail("Expected IllegalArgumentException for wrong exogenous dimension");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> model.forecast(new double[][]{{1.0, 2.0}}));
     }
 
     @Test

--- a/src/test/java/tslib/model/arima/ARIMAXTest.java
+++ b/src/test/java/tslib/model/arima/ARIMAXTest.java
@@ -1,8 +1,8 @@
 package tslib.model.arima;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ARIMAXTest {
     @Test

--- a/src/test/java/tslib/model/arima/ArimaOrderSearchParallelTest.java
+++ b/src/test/java/tslib/model/arima/ArimaOrderSearchParallelTest.java
@@ -2,8 +2,8 @@ package tslib.model.arima;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ArimaOrderSearchParallelTest {
 
@@ -82,17 +82,18 @@ public class ArimaOrderSearchParallelTest {
         assertEquals(1, result.getQ());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void searchThrowsWhenNothingFits() {
-        // Grid (0,0,0) is skipped; grid of just (0,0,0) should throw
-        ArimaOrderSearch.searchBestArima(
-                trendData(20), 0, 0, 0, ArimaOrderSearch.Criterion.AIC);
+        assertThrows(IllegalArgumentException.class, () ->
+                ArimaOrderSearch.searchBestArima(
+                        trendData(20), 0, 0, 0, ArimaOrderSearch.Criterion.AIC));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void searchThrowsOnNegativeBounds() {
-        ArimaOrderSearch.searchBestArima(
-                trendData(20), -1, 0, 0, ArimaOrderSearch.Criterion.AIC);
+        assertThrows(IllegalArgumentException.class, () ->
+                ArimaOrderSearch.searchBestArima(
+                        trendData(20), -1, 0, 0, ArimaOrderSearch.Criterion.AIC));
     }
 
     private static double rss(List<Double> residuals) {

--- a/src/test/java/tslib/model/arima/ArimaOrderSearchTest.java
+++ b/src/test/java/tslib/model/arima/ArimaOrderSearchTest.java
@@ -2,8 +2,8 @@ package tslib.model.arima;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ArimaOrderSearchTest {
 

--- a/src/test/java/tslib/model/arima/SARIMATest.java
+++ b/src/test/java/tslib/model/arima/SARIMATest.java
@@ -1,8 +1,16 @@
 package tslib.model.arima;
 
+import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SARIMATest {
 
@@ -21,5 +29,66 @@ public class SARIMATest {
         assertEquals(23.0, forecast.get(1), 1e-3);
         assertEquals(33.0, forecast.get(2), 1e-3);
         assertEquals(43.0, forecast.get(3), 1e-3);
+    }
+
+    private static List<Double> seasonalData(int periods, int m) {
+        double[] pattern = new double[m];
+        for (int i = 0; i < m; i++) {
+            pattern[i] = 10.0 + i * 5.0;
+        }
+        List<Double> data = new ArrayList<>();
+        for (int rep = 0; rep < periods; rep++) {
+            for (int i = 0; i < m; i++) {
+                data.add(pattern[i] + rep * 0.5);
+            }
+        }
+        return data;
+    }
+
+    static Stream<Arguments> sarimaCases() {
+        return Stream.of(
+            // p,d,q, P,D,Q, m, horizon
+            Arguments.of(0, 0, 0,  0, 1, 0,  4, 4),
+            Arguments.of(1, 0, 0,  0, 1, 0,  4, 4),
+            Arguments.of(0, 1, 0,  0, 1, 0,  4, 4),
+            Arguments.of(0, 0, 1,  0, 1, 0,  4, 4),
+            Arguments.of(1, 0, 0,  1, 0, 0,  4, 4),
+            Arguments.of(0, 0, 0,  0, 1, 0, 12, 12),
+            Arguments.of(1, 0, 0,  0, 1, 0, 12, 12),
+            Arguments.of(0, 1, 0,  1, 1, 0,  4, 4),
+            Arguments.of(1, 1, 0,  0, 1, 0,  4, 4),
+            Arguments.of(0, 0, 0,  1, 1, 0,  4, 4)
+        );
+    }
+
+    @ParameterizedTest(name = "SARIMA({0},{1},{2})({3},{4},{5})[{6}] forecasts {7} finite steps")
+    @MethodSource("sarimaCases")
+    public void sarimaDifferentOrdersProduceFiniteForecasts(
+            int p, int d, int q, int P, int D, int Q, int m, int horizon) {
+        List<Double> data = seasonalData(4, m);
+        SARIMA model = new SARIMA(p, d, q, P, D, Q, m).fit(data);
+        List<Double> forecast = model.forecast(horizon);
+
+        assertEquals(horizon, forecast.size());
+        for (int i = 0; i < forecast.size(); i++) {
+            assertFalse(Double.isNaN(forecast.get(i)),
+                    "Forecast step " + i + " must not be NaN");
+            assertFalse(Double.isInfinite(forecast.get(i)),
+                    "Forecast step " + i + " must not be infinite");
+        }
+    }
+
+    @ParameterizedTest(name = "SARIMA({0},{1},{2})({3},{4},{5})[{6}] residuals are non-empty and bounded")
+    @MethodSource("sarimaCases")
+    public void sarimaResidualsAreNonEmptyAndBounded(
+            int p, int d, int q, int P, int D, int Q, int m, int horizon) {
+        List<Double> data = seasonalData(4, m);
+        SARIMA model = new SARIMA(p, d, q, P, D, Q, m).fit(data);
+        List<Double> residuals = model.getResiduals();
+        assertFalse(residuals.isEmpty(), "Residuals must not be empty");
+        assertTrue(residuals.size() <= data.size(), "Residuals must not exceed data size");
+        for (int i = 0; i < residuals.size(); i++) {
+            assertFalse(Double.isNaN(residuals.get(i)), "Residual at index " + i + " must not be NaN");
+        }
     }
 }

--- a/src/test/java/tslib/model/statespace/LocalLevelModelTest.java
+++ b/src/test/java/tslib/model/statespace/LocalLevelModelTest.java
@@ -1,8 +1,8 @@
 package tslib.model.statespace;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LocalLevelModelTest {
 

--- a/src/test/java/tslib/movingaverage/CumulativeMovingAverageTest.java
+++ b/src/test/java/tslib/movingaverage/CumulativeMovingAverageTest.java
@@ -1,11 +1,11 @@
 package tslib.movingaverage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CumulativeMovingAverageTest {
 

--- a/src/test/java/tslib/movingaverage/ExponentialMovingAverageTest.java
+++ b/src/test/java/tslib/movingaverage/ExponentialMovingAverageTest.java
@@ -1,11 +1,11 @@
 package tslib.movingaverage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExponentialMovingAverageTest {
 
@@ -26,7 +26,7 @@ public class ExponentialMovingAverageTest {
             double prev = output.get(i - 1);
             double curr = output.get(i);
             double actual = input.get(i);
-            assertTrue("EMA should move toward input", (curr > prev && curr < actual) || (curr < prev && curr > actual));
+            assertTrue((curr > prev && curr < actual) || (curr < prev && curr > actual), "EMA should move toward input");
         }
     }
 
@@ -45,13 +45,13 @@ public class ExponentialMovingAverageTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidAlphaZero() {
-        new ExponentialMovingAverage(0.0);
+        assertThrows(IllegalArgumentException.class, () -> new ExponentialMovingAverage(0.0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidAlphaGreaterThanOne() {
-        new ExponentialMovingAverage(1.1);
+        assertThrows(IllegalArgumentException.class, () -> new ExponentialMovingAverage(1.1));
     }
 }

--- a/src/test/java/tslib/movingaverage/MovingAverageRegressionTest.java
+++ b/src/test/java/tslib/movingaverage/MovingAverageRegressionTest.java
@@ -1,8 +1,8 @@
 package tslib.movingaverage;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MovingAverageRegressionTest {
     @Test

--- a/src/test/java/tslib/movingaverage/SimpleMovingAverageTest.java
+++ b/src/test/java/tslib/movingaverage/SimpleMovingAverageTest.java
@@ -1,11 +1,11 @@
 package tslib.movingaverage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SimpleMovingAverageTest {
 
@@ -51,8 +51,8 @@ public class SimpleMovingAverageTest {
         assertTrue(result.isEmpty());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidPeriod() {
-        new SimpleMovingAverage(0); // Should throw exception
+        assertThrows(IllegalArgumentException.class, () -> new SimpleMovingAverage(0));
     }
 }

--- a/src/test/java/tslib/movingaverage/WeightedMovingAverageTest.java
+++ b/src/test/java/tslib/movingaverage/WeightedMovingAverageTest.java
@@ -1,8 +1,8 @@
 package tslib.movingaverage;
 
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +18,7 @@ public class WeightedMovingAverageTest {
 
     private WeightedMovingAverage wma;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         wma = new WeightedMovingAverage(5);
     }
@@ -31,19 +31,19 @@ public class WeightedMovingAverageTest {
         assertNotNull(wma10);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithInvalidPeriodZero() {
-        new WeightedMovingAverage(0);
+        assertThrows(IllegalArgumentException.class, () -> new WeightedMovingAverage(0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithInvalidPeriodNegative() {
-        new WeightedMovingAverage(-1);
+        assertThrows(IllegalArgumentException.class, () -> new WeightedMovingAverage(-1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithInvalidPeriodNegativeFive() {
-        new WeightedMovingAverage(-5);
+        assertThrows(IllegalArgumentException.class, () -> new WeightedMovingAverage(-5));
     }
 
     @Test

--- a/src/test/java/tslib/selection/AutoSelectionEdgeCaseTest.java
+++ b/src/test/java/tslib/selection/AutoSelectionEdgeCaseTest.java
@@ -1,9 +1,9 @@
 package tslib.selection;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import tslib.model.arima.ArimaOrderSearch;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AutoSelectionEdgeCaseTest {
 

--- a/src/test/java/tslib/selection/AutoSelectionTest.java
+++ b/src/test/java/tslib/selection/AutoSelectionTest.java
@@ -1,9 +1,9 @@
 package tslib.selection;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import tslib.model.arima.ArimaOrderSearch;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AutoSelectionTest {
     @Test

--- a/src/test/java/tslib/stats/StatsFacadeTest.java
+++ b/src/test/java/tslib/stats/StatsFacadeTest.java
@@ -1,8 +1,8 @@
 package tslib.stats;
 
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StatsFacadeTest {
     @Test

--- a/src/test/java/tslib/tests/KPSSTestTest.java
+++ b/src/test/java/tslib/tests/KPSSTestTest.java
@@ -3,8 +3,8 @@ package tslib.tests;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class KPSSTestTest {
 

--- a/src/test/java/tslib/transform/BoxCoxOptimizationTest.java
+++ b/src/test/java/tslib/transform/BoxCoxOptimizationTest.java
@@ -2,8 +2,8 @@ package tslib.transform;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BoxCoxOptimizationTest {
 
@@ -43,7 +43,7 @@ public class BoxCoxOptimizationTest {
             data.add(Math.exp(i * 0.5));
         }
         double lambda = Transform.boxCoxLambdaSearch(data);
-        assertTrue("Expected lambda near 0 for exponential data, got " + lambda, lambda < 0.3);
+        assertTrue(lambda < 0.3, "Expected lambda near 0 for exponential data, got " + lambda);
     }
 
     @Test
@@ -60,9 +60,10 @@ public class BoxCoxOptimizationTest {
         assertTrue(lambda >= 0.0 && lambda <= 1.0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void boxCoxThrowsOnNonPositiveValues() {
-        Transform.boxCox(Arrays.asList(1.0, -1.0, 3.0));
+        assertThrows(IllegalArgumentException.class, () ->
+                Transform.boxCox(Arrays.asList(1.0, -1.0, 3.0)));
     }
 
     @Test

--- a/src/test/java/tslib/transform/DifferencingTest.java
+++ b/src/test/java/tslib/transform/DifferencingTest.java
@@ -2,9 +2,9 @@ package tslib.transform;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DifferencingTest {
 

--- a/src/test/java/tslib/transform/TransformTest.java
+++ b/src/test/java/tslib/transform/TransformTest.java
@@ -2,8 +2,8 @@ package tslib.transform;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TransformTest {
     @Test
@@ -17,9 +17,9 @@ public class TransformTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void logRejectsNonPositiveValues() {
-        Transform.log(List.of(1.0, 0.0, 2.0));
+        assertThrows(IllegalArgumentException.class, () -> Transform.log(List.of(1.0, 0.0, 2.0)));
     }
 
     @Test
@@ -54,9 +54,9 @@ public class TransformTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void inverseBoxCoxThrowsWhenInnerNonPositive() {
-        // lambda=2, y=-1: y*lambda+1 = -1*2+1 = -1 <= 0
-        Transform.inverseBoxCox(Arrays.asList(-1.0), 2.0);
+        assertThrows(IllegalArgumentException.class, () ->
+                Transform.inverseBoxCox(Arrays.asList(-1.0), 2.0));
     }
 }

--- a/src/test/java/tslib/tstest/AugmentedDickeyFullerTest.java
+++ b/src/test/java/tslib/tstest/AugmentedDickeyFullerTest.java
@@ -2,8 +2,8 @@ package tslib.tstest;
 
 import java.util.ArrayList;
 import tslib.tests.*;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit Test for Augmented Dickey Fuller
@@ -19,7 +19,7 @@ public class AugmentedDickeyFullerTest {
         }
         AugmentedDickeyFuller adf = new AugmentedDickeyFuller(x);
         System.out.println("ADF stat (linear trend): " + adf.getAdfStat());
-        assertFalse("Expected non-stationary series", adf.isNeedsDiff());
+        assertFalse(adf.isNeedsDiff(), "Expected non-stationary series");
     }
 
     @Test
@@ -31,7 +31,7 @@ public class AugmentedDickeyFullerTest {
         x.set(50, 1000.0);  // Inject an outlier
         AugmentedDickeyFuller adf = new AugmentedDickeyFuller(x);
         System.out.println("ADF stat (trend + outlier): " + adf.getAdfStat());
-        assertFalse("Expected non-stationary series with outlier", adf.isNeedsDiff());
+        assertFalse(adf.isNeedsDiff(), "Expected non-stationary series with outlier");
     }
 
     @Test
@@ -42,7 +42,7 @@ public class AugmentedDickeyFullerTest {
         }
         AugmentedDickeyFuller adf = new AugmentedDickeyFuller(x);
         double pValue = adf.getPValue();
-        assertTrue("p-value must be in [0.01, 0.10]", pValue >= 0.01 && pValue <= 0.10);
+        assertTrue(pValue >= 0.01 && pValue <= 0.10, "p-value must be in [0.01, 0.10]");
     }
 
     @Test
@@ -55,8 +55,7 @@ public class AugmentedDickeyFullerTest {
         }
         AugmentedDickeyFuller adf = new AugmentedDickeyFuller(x);
         // White noise is stationary; ADF stat should be very negative
-        assertTrue("Stationary series should have ADF stat < -3.0", adf.getAdfStat() < -3.0);
-        assertEquals("p-value should be at lower boundary (0.01) for stationary white noise",
-                0.01, adf.getPValue(), 1e-9);
+        assertTrue(adf.getAdfStat() < -3.0, "Stationary series should have ADF stat < -3.0");
+        assertEquals(0.01, adf.getPValue(), 1e-9, "p-value should be at lower boundary (0.01) for stationary white noise");
     }
 }

--- a/src/test/java/tslib/util/LinearAlgebraTest.java
+++ b/src/test/java/tslib/util/LinearAlgebraTest.java
@@ -2,8 +2,8 @@ package tslib.util;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LinearAlgebraTest {
 

--- a/src/test/java/tslib/util/StatsOptimizationTest.java
+++ b/src/test/java/tslib/util/StatsOptimizationTest.java
@@ -2,8 +2,8 @@ package tslib.util;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StatsOptimizationTest {
 
@@ -76,14 +76,14 @@ public class StatsOptimizationTest {
         assertEquals(-10.0, Stats.getMinimum(data), 1e-15);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getMinimumIndexThrowsOnEmpty() {
-        Stats.getMinimumIndex(Arrays.asList());
+        assertThrows(IllegalArgumentException.class, () -> Stats.getMinimumIndex(Arrays.asList()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getMaximumIndexThrowsOnEmpty() {
-        Stats.getMaximumIndex(Arrays.asList());
+        assertThrows(IllegalArgumentException.class, () -> Stats.getMaximumIndex(Arrays.asList()));
     }
 
     @Test


### PR DESCRIPTION
  7. Thread-safe Collect caches — cached fields (mean, variance, etc.…) have a data race; add volatile or compute lazily with synchronized.
  8. Nelder-Mead or Brent optimizer for AutoETS — the 4-point grid {0.2, 0.4, 0.6, 0.8} misses optima; even a golden-section search over [0,1] per parameter would improve fit quality significantly. gives correct intervals and is standard.
  10. Upgrade to JUnit 5 — enables parameterized tests, which would dramatically improve ARIMA/SARIMA coverage (currently only 3 tests each for the most complex models).