### PR TITLE
  Features Implemented: Model Serialization,  LocalLevelModel MLE Optimization, VAR (Vector Autoregression),  STL Robustness Iterations, In-Memory Collect Constructor

### DIFF
--- a/src/main/java/tslib/collect/Collect.java
+++ b/src/main/java/tslib/collect/Collect.java
@@ -41,9 +41,42 @@ public class Collect {
     }
 
     /**
-     * Private file reader method
+     * In-memory constructor: wraps an existing {@code List<Double>} without file I/O.
+     */
+    public Collect(List<Double> data, int k, int n) {
+        if (data == null || data.isEmpty()) {
+            throw new IllegalArgumentException("Data must not be null or empty.");
+        }
+        this._filepath = null;
+        this._k = k;
+        this._n = n;
+        this._data = new ArrayList<>(data);
+    }
+
+    /**
+     * In-memory constructor: wraps a primitive {@code double[]} without file I/O.
+     */
+    public Collect(double[] data, int k, int n) {
+        if (data == null || data.length == 0) {
+            throw new IllegalArgumentException("Data must not be null or empty.");
+        }
+        this._filepath = null;
+        this._k = k;
+        this._n = n;
+        List<Double> list = new ArrayList<>(data.length);
+        for (double v : data) {
+            list.add(v);
+        }
+        this._data = list;
+    }
+
+    /**
+     * Reads the source file. Returns the in-memory data directly when no filepath was given.
      */
     public List<Double> readFile() throws IOException {
+        if (_filepath == null) {
+            return new ArrayList<>(_data);
+        }
         return Util.readFile(_filepath);
     }
 

--- a/src/main/java/tslib/decomposition/STLDecomposition.java
+++ b/src/main/java/tslib/decomposition/STLDecomposition.java
@@ -1,24 +1,39 @@
 package tslib.decomposition;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 /**
- * A compact STL-style decomposition with loess smoothing for trend extraction.
+ * STL-style decomposition with loess smoothing and optional robustness re-weighting.
+ *
+ * <p>When {@code outerIterations > 0} the algorithm applies Cleveland et al. (1990)
+ * robustness re-weighting: after each outer pass the remainder is used to compute
+ * bisquare robustness weights that down-weight outliers in the next pass, making the
+ * decomposition less sensitive to anomalous observations.
  */
 public class STLDecomposition {
+
+    /** Multiplier for the robust bandwidth: h = BISQUARE_H_FACTOR * median(|remainder|). */
+    private static final double BISQUARE_H_FACTOR = 6.0;
+    private static final double BISQUARE_GUARD = 1e-10;
 
     private final int period;
     private final int trendWindow;
     private final int seasonalWindow;
     private final int iterations;
+    private final int outerIterations;
 
     public STLDecomposition(int period) {
-        this(period, Math.max(7, toOdd(period + 1)), 7, 2);
+        this(period, Math.max(7, toOdd(period + 1)), 7, 2, 0);
     }
 
     public STLDecomposition(int period, int trendWindow, int seasonalWindow, int iterations) {
+        this(period, trendWindow, seasonalWindow, iterations, 0);
+    }
+
+    public STLDecomposition(int period, int trendWindow, int seasonalWindow, int iterations, int outerIterations) {
         if (period < 2) {
             throw new IllegalArgumentException("Period must be >= 2");
         }
@@ -31,10 +46,14 @@ public class STLDecomposition {
         if (iterations < 1) {
             throw new IllegalArgumentException("Iterations must be >= 1");
         }
+        if (outerIterations < 0) {
+            throw new IllegalArgumentException("Outer iterations must be >= 0");
+        }
         this.period = period;
         this.trendWindow = trendWindow;
         this.seasonalWindow = seasonalWindow;
         this.iterations = iterations;
+        this.outerIterations = outerIterations;
     }
 
     public Result decompose(List<Double> data) {
@@ -43,22 +62,33 @@ public class STLDecomposition {
         double[] values = toArray(data);
         double[] trend = centeredMovingAverage(values, Math.max(period, trendWindow));
         double[] seasonal = new double[n];
-        double[] remainder = new double[n];
 
-        for (int iteration = 0; iteration < iterations; iteration++) {
-            double[] detrended = new double[n];
-            for (int i = 0; i < n; i++) {
-                detrended[i] = values[i] - trend[i];
+        double[] robustnessWeights = null; // null = unit weights (no robustness)
+
+        for (int outer = 0; outer <= outerIterations; outer++) {
+            for (int iteration = 0; iteration < iterations; iteration++) {
+                double[] detrended = new double[n];
+                for (int i = 0; i < n; i++) {
+                    detrended[i] = values[i] - trend[i];
+                }
+                seasonal = estimateSeasonal(detrended, period, seasonalWindow, robustnessWeights);
+                double[] deseasonalized = new double[n];
+                for (int i = 0; i < n; i++) {
+                    deseasonalized[i] = values[i] - seasonal[i];
+                }
+                trend = loessSmooth(deseasonalized, trendWindow, robustnessWeights);
             }
 
-            seasonal = estimateSeasonal(detrended, period, seasonalWindow);
-            double[] deseasonalized = new double[n];
-            for (int i = 0; i < n; i++) {
-                deseasonalized[i] = values[i] - seasonal[i];
+            if (outer < outerIterations) {
+                double[] remainder = new double[n];
+                for (int i = 0; i < n; i++) {
+                    remainder[i] = values[i] - trend[i] - seasonal[i];
+                }
+                robustnessWeights = computeRobustnessWeights(remainder);
             }
-            trend = loessSmooth(deseasonalized, trendWindow);
         }
 
+        double[] remainder = new double[n];
         for (int i = 0; i < n; i++) {
             remainder[i] = values[i] - trend[i] - seasonal[i];
         }
@@ -66,7 +96,38 @@ public class STLDecomposition {
         return new Result(toList(trend), toList(seasonal), toList(remainder));
     }
 
-    private double[] estimateSeasonal(double[] detrended, int period, int window) {
+    private double[] computeRobustnessWeights(double[] remainder) {
+        double[] absRemainder = new double[remainder.length];
+        for (int i = 0; i < remainder.length; i++) {
+            absRemainder[i] = Math.abs(remainder[i]);
+        }
+        double median = computeMedian(absRemainder);
+        double h = BISQUARE_H_FACTOR * median + BISQUARE_GUARD;
+
+        double[] weights = new double[remainder.length];
+        for (int i = 0; i < remainder.length; i++) {
+            double u = absRemainder[i] / h;
+            if (u < 1.0) {
+                double base = 1.0 - u * u;
+                weights[i] = base * base;
+            } else {
+                weights[i] = 0.0;
+            }
+        }
+        return weights;
+    }
+
+    private double computeMedian(double[] values) {
+        double[] sorted = Arrays.copyOf(values, values.length);
+        Arrays.sort(sorted);
+        int mid = sorted.length / 2;
+        if (sorted.length % 2 == 0) {
+            return (sorted[mid - 1] + sorted[mid]) / 2.0;
+        }
+        return sorted[mid];
+    }
+
+    private double[] estimateSeasonal(double[] detrended, int period, int window, double[] robustnessWeights) {
         int n = detrended.length;
         double[] seasonal = new double[n];
         double[] cycleMeans = new double[period];
@@ -78,7 +139,16 @@ public class STLDecomposition {
                 subseries.add(detrended[i]);
                 indices.add(i);
             }
-            double[] smoothed = loessSmooth(toArray(subseries), Math.min(window, toOdd(subseries.size())));
+
+            double[] subWeights = null;
+            if (robustnessWeights != null) {
+                subWeights = new double[subseries.size()];
+                for (int i = 0; i < indices.size(); i++) {
+                    subWeights[i] = robustnessWeights[indices.get(i)];
+                }
+            }
+
+            double[] smoothed = loessSmooth(toArray(subseries), Math.min(window, toOdd(subseries.size())), subWeights);
             for (int i = 0; i < smoothed.length; i++) {
                 seasonal[indices.get(i)] = smoothed[i];
                 cycleMeans[offset] += smoothed[i];
@@ -101,10 +171,14 @@ public class STLDecomposition {
     }
 
     private double[] centeredMovingAverage(double[] values, int window) {
-        return loessSmooth(values, toOdd(window));
+        return loessSmooth(values, toOdd(window), null);
     }
 
     private double[] loessSmooth(double[] values, int window) {
+        return loessSmooth(values, window, null);
+    }
+
+    private double[] loessSmooth(double[] values, int window, double[] robustnessWeights) {
         if (values.length == 0) {
             return new double[0];
         }
@@ -136,6 +210,9 @@ public class STLDecomposition {
             for (int j = left; j <= right; j++) {
                 double distance = Math.abs(j - i) / maxDistance;
                 double weight = tricube(distance);
+                if (robustnessWeights != null) {
+                    weight *= robustnessWeights[j];
+                }
                 double x = j;
                 double y = values[j];
                 sw += weight;
@@ -143,6 +220,11 @@ public class STLDecomposition {
                 sy += weight * y;
                 sxx += weight * x * x;
                 sxy += weight * x * y;
+            }
+
+            if (sw == 0.0) {
+                smoothed[i] = values[i];
+                continue;
             }
 
             double denominator = sw * sxx - sx * sx;

--- a/src/main/java/tslib/model/arima/ARIMA.java
+++ b/src/main/java/tslib/model/arima/ARIMA.java
@@ -1,5 +1,6 @@
 package tslib.model.arima;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -15,8 +16,9 @@ import tslib.util.LinearAlgebra;
  * This implementation is intentionally small and dependency-light. It supports manual order
  * selection and is designed for straightforward forecasting workflows inside this library.
  */
-public class ARIMA {
+public class ARIMA implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private static final double DEFAULT_RIDGE = 1e-6;
     private static final int DEFAULT_MAX_ITERATIONS = 200;
     private static final double DEFAULT_TOLERANCE = 1e-8;

--- a/src/main/java/tslib/model/arima/ARIMAX.java
+++ b/src/main/java/tslib/model/arima/ARIMAX.java
@@ -1,5 +1,6 @@
 package tslib.model.arima;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -9,8 +10,9 @@ import tslib.util.LinearAlgebra;
 /**
  * Basic ARIMAX(p, d, q) model with contemporaneous exogenous regressors.
  */
-public class ARIMAX {
+public class ARIMAX implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private static final double DEFAULT_RIDGE = 1e-6;
     private static final int DEFAULT_MAX_ITERATIONS = 200;
     private static final double DEFAULT_TOLERANCE = 1e-8;

--- a/src/main/java/tslib/model/arima/SARIMA.java
+++ b/src/main/java/tslib/model/arima/SARIMA.java
@@ -1,5 +1,6 @@
 package tslib.model.arima;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,8 +17,9 @@ import tslib.util.LinearAlgebra;
  * dependency-light, and easy to reason about. Seasonal AR and MA terms are fitted together with
  * the non-seasonal terms after applying the requested regular and seasonal differencing.
  */
-public class SARIMA {
+public class SARIMA implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private static final double DEFAULT_RIDGE = 1e-6;
     private static final int DEFAULT_MAX_ITERATIONS = 200;
     private static final double DEFAULT_TOLERANCE = 1e-8;

--- a/src/main/java/tslib/model/arima/VARModel.java
+++ b/src/main/java/tslib/model/arima/VARModel.java
@@ -1,0 +1,243 @@
+package tslib.model.arima;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import tslib.util.LinearAlgebra;
+
+/**
+ * Vector Autoregression (VAR) model for multivariate time series.
+ *
+ * <p>A VAR(p) model jointly models K endogenous series via:
+ * <pre>  Y_t = c + A_1 Y_{t-1} + ... + A_p Y_{t-p} + e_t</pre>
+ * where each A_i is a K×K coefficient matrix. Each equation is estimated
+ * independently by ordinary least squares with a small ridge penalty.
+ *
+ * <p>Use {@link #fitOptimal(List, int)} to select the lag order by AIC.
+ */
+public class VARModel implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final double DEFAULT_RIDGE = 1e-6;
+
+    private final int lagOrder;
+    private boolean fitted;
+    private int numSeries;
+    private int effectiveObs;
+
+    /** coefficients[k] has length 1 + lagOrder * numSeries. */
+    private double[][] coefficients;
+    /** residuals[k] has length effectiveObs. */
+    private double[][] residuals;
+    private List<List<Double>> trainingData;
+
+    public VARModel(int lagOrder) {
+        if (lagOrder < 1) {
+            throw new IllegalArgumentException("Lag order must be >= 1");
+        }
+        this.lagOrder = lagOrder;
+    }
+
+    /**
+     * Fits the VAR(p) model to the given multivariate series.
+     *
+     * @param series list of K series, each of the same length T; requires T > lagOrder
+     * @return this (fluent)
+     */
+    public VARModel fit(List<List<Double>> series) {
+        validateInput(series);
+        this.numSeries = series.size();
+        int seriesLength = series.get(0).size();
+        this.effectiveObs = seriesLength - lagOrder;
+
+        List<List<Double>> dataCopy = new ArrayList<>(numSeries);
+        for (List<Double> s : series) {
+            dataCopy.add(Collections.unmodifiableList(new ArrayList<>(s)));
+        }
+        this.trainingData = Collections.unmodifiableList(dataCopy);
+
+        double[][] designMatrix = buildDesignMatrix(series, seriesLength);
+
+        this.coefficients = new double[numSeries][];
+        this.residuals = new double[numSeries][effectiveObs];
+        for (int k = 0; k < numSeries; k++) {
+            double[] targets = new double[effectiveObs];
+            for (int row = 0; row < effectiveObs; row++) {
+                targets[row] = series.get(k).get(row + lagOrder);
+            }
+            coefficients[k] = LinearAlgebra.ordinaryLeastSquares(designMatrix, targets, DEFAULT_RIDGE);
+            for (int row = 0; row < effectiveObs; row++) {
+                residuals[k][row] = targets[row] - dot(coefficients[k], designMatrix[row]);
+            }
+        }
+
+        this.fitted = true;
+        return this;
+    }
+
+    /**
+     * Forecasts {@code steps} periods ahead for each series.
+     *
+     * @param steps number of future steps
+     * @return list of K forecast lists, each of length {@code steps}
+     */
+    public List<List<Double>> forecast(int steps) {
+        requireFitted();
+        if (steps < 1) {
+            throw new IllegalArgumentException("Steps must be >= 1");
+        }
+
+        List<List<Double>> history = new ArrayList<>(numSeries);
+        for (int k = 0; k < numSeries; k++) {
+            history.add(new ArrayList<>(trainingData.get(k)));
+        }
+
+        List<List<Double>> forecasts = new ArrayList<>(numSeries);
+        for (int k = 0; k < numSeries; k++) {
+            forecasts.add(new ArrayList<>(steps));
+        }
+
+        for (int h = 0; h < steps; h++) {
+            int currentSize = history.get(0).size();
+            double[] featureVector = buildFeatureVector(history, currentSize);
+            for (int k = 0; k < numSeries; k++) {
+                double prediction = dot(coefficients[k], featureVector);
+                forecasts.get(k).add(prediction);
+                history.get(k).add(prediction);
+            }
+        }
+
+        return forecasts;
+    }
+
+    /**
+     * Akaike Information Criterion: sum_k[T_eff * log(RSS_k / T_eff)] + 2*K*(1 + p*K).
+     */
+    public double getAic() {
+        requireFitted();
+        int k = numSeries;
+        double aic = 0.0;
+        for (int eq = 0; eq < k; eq++) {
+            double rss = 0.0;
+            for (double r : residuals[eq]) {
+                rss += r * r;
+            }
+            aic += effectiveObs * Math.log(Math.max(rss / effectiveObs, Double.MIN_VALUE));
+        }
+        return aic + 2.0 * k * (1 + lagOrder * k);
+    }
+
+    /**
+     * Fits VAR models for each lag from 1 to {@code maxLag} and returns the one with
+     * the lowest AIC.
+     */
+    public static VARModel fitOptimal(List<List<Double>> series, int maxLag) {
+        if (series == null || series.isEmpty()) {
+            throw new IllegalArgumentException("Series must not be null or empty");
+        }
+        if (maxLag < 1) {
+            throw new IllegalArgumentException("maxLag must be >= 1");
+        }
+        VARModel best = null;
+        double bestAic = Double.POSITIVE_INFINITY;
+        for (int p = 1; p <= maxLag; p++) {
+            VARModel candidate = new VARModel(p);
+            try {
+                candidate.fit(series);
+                double aic = candidate.getAic();
+                if (aic < bestAic) {
+                    bestAic = aic;
+                    best = candidate;
+                }
+            } catch (IllegalArgumentException ignored) {
+                // not enough data for this lag order
+            }
+        }
+        if (best == null) {
+            throw new IllegalArgumentException("No valid VAR model could be fitted with the given data and maxLag");
+        }
+        return best;
+    }
+
+    /** Returns the coefficient matrix: {@code coefficients[k][j]} for equation k, feature j. */
+    public double[][] getCoefficients() {
+        requireFitted();
+        double[][] copy = new double[numSeries][];
+        for (int k = 0; k < numSeries; k++) {
+            copy[k] = java.util.Arrays.copyOf(coefficients[k], coefficients[k].length);
+        }
+        return copy;
+    }
+
+    public int getLagOrder() {
+        return lagOrder;
+    }
+
+    public int getNumSeries() {
+        requireFitted();
+        return numSeries;
+    }
+
+    private double[][] buildDesignMatrix(List<List<Double>> series, int seriesLength) {
+        double[][] matrix = new double[effectiveObs][1 + lagOrder * numSeries];
+        for (int row = 0; row < effectiveObs; row++) {
+            int t = row + lagOrder;
+            int col = 0;
+            matrix[row][col++] = 1.0;
+            for (int lag = 1; lag <= lagOrder; lag++) {
+                for (int k = 0; k < numSeries; k++) {
+                    matrix[row][col++] = series.get(k).get(t - lag);
+                }
+            }
+        }
+        return matrix;
+    }
+
+    private double[] buildFeatureVector(List<List<Double>> history, int currentIndex) {
+        int numCols = 1 + lagOrder * numSeries;
+        double[] vector = new double[numCols];
+        int col = 0;
+        vector[col++] = 1.0;
+        for (int lag = 1; lag <= lagOrder; lag++) {
+            int index = currentIndex - lag;
+            for (int k = 0; k < numSeries; k++) {
+                vector[col++] = history.get(k).get(index);
+            }
+        }
+        return vector;
+    }
+
+    private double dot(double[] a, double[] b) {
+        double sum = 0.0;
+        for (int i = 0; i < a.length; i++) {
+            sum += a[i] * b[i];
+        }
+        return sum;
+    }
+
+    private void validateInput(List<List<Double>> series) {
+        if (series == null || series.size() < 2) {
+            throw new IllegalArgumentException("VAR requires at least 2 series");
+        }
+        int length = series.get(0).size();
+        if (length <= lagOrder) {
+            throw new IllegalArgumentException("Series length must exceed lag order");
+        }
+        for (List<Double> s : series) {
+            if (s == null || s.size() != length) {
+                throw new IllegalArgumentException("All series must be non-null and have the same length");
+            }
+        }
+        int minObs = lagOrder * series.size() + 2;
+        if (length - lagOrder < minObs - lagOrder) {
+            throw new IllegalArgumentException("Not enough observations to estimate VAR(" + lagOrder + ")");
+        }
+    }
+
+    private void requireFitted() {
+        if (!fitted) {
+            throw new IllegalStateException("Model must be fitted before calling this method");
+        }
+    }
+}

--- a/src/main/java/tslib/model/expsmoothing/DoubleExpSmoothing.java
+++ b/src/main/java/tslib/model/expsmoothing/DoubleExpSmoothing.java
@@ -1,12 +1,15 @@
 package tslib.model.expsmoothing;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Double Exponential Smoothing (Holt's Linear Trend Method).
  */
-public class DoubleExpSmoothing implements ExponentialSmoothing {
+public class DoubleExpSmoothing implements ExponentialSmoothing, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final double alpha;
     private final double gamma;

--- a/src/main/java/tslib/model/expsmoothing/SingleExpSmoothing.java
+++ b/src/main/java/tslib/model/expsmoothing/SingleExpSmoothing.java
@@ -1,12 +1,15 @@
 package tslib.model.expsmoothing;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Single Exponential Smoothing implementation.
  */
-public class SingleExpSmoothing implements ExponentialSmoothing {
+public class SingleExpSmoothing implements ExponentialSmoothing, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final double alpha;
 

--- a/src/main/java/tslib/model/expsmoothing/TripleExpSmoothing.java
+++ b/src/main/java/tslib/model/expsmoothing/TripleExpSmoothing.java
@@ -1,12 +1,15 @@
 package tslib.model.expsmoothing;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Triple Exponential Smoothing (Holt-Winters Multiplicative Method).
  */
-public class TripleExpSmoothing implements ExponentialSmoothing {
+public class TripleExpSmoothing implements ExponentialSmoothing, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final double alpha;
     private final double beta;

--- a/src/main/java/tslib/model/statespace/KalmanFilter.java
+++ b/src/main/java/tslib/model/statespace/KalmanFilter.java
@@ -1,5 +1,6 @@
 package tslib.model.statespace;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -7,7 +8,9 @@ import java.util.List;
 /**
  * One-dimensional Kalman filter for the local-level state-space model.
  */
-public class KalmanFilter {
+public class KalmanFilter implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final double processVariance;
     private final double observationVariance;
@@ -100,7 +103,10 @@ public class KalmanFilter {
         }
     }
 
-    public static final class Result {
+    public static final class Result implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
         private final List<Double> predictedStates;
         private final List<Double> filteredStates;
         private final List<Double> filteredCovariances;

--- a/src/main/java/tslib/model/statespace/LocalLevelModel.java
+++ b/src/main/java/tslib/model/statespace/LocalLevelModel.java
@@ -1,17 +1,35 @@
 package tslib.model.statespace;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.math3.analysis.UnivariateFunction;
+import org.apache.commons.math3.optim.MaxEval;
+import org.apache.commons.math3.optim.nonlinear.scalar.GoalType;
+import org.apache.commons.math3.optim.univariate.BrentOptimizer;
+import org.apache.commons.math3.optim.univariate.SearchInterval;
+import org.apache.commons.math3.optim.univariate.UnivariateObjectiveFunction;
 import tslib.evaluation.ForecastIntervals;
 import tslib.evaluation.IntervalForecast;
 import tslib.evaluation.PredictionInterval;
 
 /**
- * Local-level state-space model with simple variance search.
+ * Local-level state-space model with MLE optimization via Brent search.
+ *
+ * <p>The observation variance is estimated from the first-difference variance of the
+ * series. The process variance is found by maximising the Kalman-filter log-likelihood
+ * over a log-transformed ratio search interval, using the Brent algorithm (exact MLE
+ * rather than a 7-point grid).
  */
-public class LocalLevelModel {
+public class LocalLevelModel implements Serializable {
 
-    private static final double[] PROCESS_RATIO_GRID = {0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0};
+    private static final long serialVersionUID = 1L;
+
+    /** Log-scale lower bound for the q/r ratio search: log(1e-4). */
+    private static final double LOG_MIN_RATIO = Math.log(1e-4);
+    /** Log-scale upper bound for the q/r ratio search: log(1e4). */
+    private static final double LOG_MAX_RATIO = Math.log(1e4);
+    private static final int MAX_BRENT_EVALS = 200;
 
     private KalmanFilter filter;
     private KalmanFilter.Result result;
@@ -25,31 +43,29 @@ public class LocalLevelModel {
         }
         this.data = new ArrayList<>(observations);
 
-        double baseScale = estimateDifferenceVariance(observations);
-        double bestScore = Double.NEGATIVE_INFINITY;
-        KalmanFilter bestFilter = null;
-        KalmanFilter.Result bestResult = null;
-        double bestQ = 0.0;
-        double bestR = 0.0;
+        final double baseScale = estimateDifferenceVariance(observations);
+        final double r = Math.max(1e-6, baseScale);
+        final List<Double> obs = this.data;
 
-        for (double ratio : PROCESS_RATIO_GRID) {
-            double q = Math.max(1e-6, baseScale * ratio);
-            double r = Math.max(1e-6, baseScale);
-            KalmanFilter candidate = new KalmanFilter(q, r);
-            KalmanFilter.Result candidateResult = candidate.filter(observations);
-            if (candidateResult.getLogLikelihood() > bestScore) {
-                bestScore = candidateResult.getLogLikelihood();
-                bestFilter = candidate;
-                bestResult = candidateResult;
-                bestQ = q;
-                bestR = r;
-            }
-        }
+        BrentOptimizer optimizer = new BrentOptimizer(1e-8, 1e-10);
+        double bestLogRatio = optimizer.optimize(
+                new MaxEval(MAX_BRENT_EVALS),
+                new UnivariateObjectiveFunction(new UnivariateFunction() {
+                    @Override
+                    public double value(double logRatio) {
+                        double q = Math.max(1e-6, baseScale * Math.exp(logRatio));
+                        return -new KalmanFilter(q, r).filter(obs).getLogLikelihood();
+                    }
+                }),
+                GoalType.MINIMIZE,
+                new SearchInterval(LOG_MIN_RATIO, LOG_MAX_RATIO)
+        ).getPoint();
 
-        this.filter = bestFilter;
-        this.result = bestResult;
+        double bestQ = Math.max(1e-6, baseScale * Math.exp(bestLogRatio));
+        this.filter = new KalmanFilter(bestQ, r);
+        this.result = this.filter.filter(observations);
         this.processVariance = bestQ;
-        this.observationVariance = bestR;
+        this.observationVariance = r;
         return this;
     }
 

--- a/src/main/java/tslib/util/ModelSerializer.java
+++ b/src/main/java/tslib/util/ModelSerializer.java
@@ -1,0 +1,49 @@
+package tslib.util;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * Saves and restores fitted models so they don't need to be re-trained on startup.
+ *
+ * <p>All model classes in this library implement {@link Serializable}. Use
+ * {@link #save(Serializable, String)} after fitting and {@link #load(String)} when
+ * reloading from disk.
+ */
+public final class ModelSerializer {
+
+    private ModelSerializer() {}
+
+    /**
+     * Serializes {@code model} to the file at {@code path}.
+     *
+     * @param model the fitted model to persist
+     * @param path  destination file path
+     * @throws IOException if the file cannot be written
+     */
+    public static void save(Serializable model, String path) throws IOException {
+        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(path))) {
+            oos.writeObject(model);
+        }
+    }
+
+    /**
+     * Deserializes a model previously saved by {@link #save}.
+     *
+     * @param path source file path
+     * @param <T>  inferred model type
+     * @return the deserialized model
+     * @throws IOException            if the file cannot be read
+     * @throws ClassNotFoundException if the serialized class is not on the classpath
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T load(String path) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(path))) {
+            return (T) ois.readObject();
+        }
+    }
+}

--- a/src/test/java/tslib/collect/CollectInMemoryTest.java
+++ b/src/test/java/tslib/collect/CollectInMemoryTest.java
@@ -1,0 +1,104 @@
+package tslib.collect;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CollectInMemoryTest {
+
+    private static final double[] ARRAY_DATA = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+    private static final List<Double> LIST_DATA = List.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0);
+
+    @Test
+    public void doubleArrayConstructorComputesCorrectAverage() {
+        Collect c = new Collect(ARRAY_DATA, 1, 3);
+        assertEquals(5.5, c.getAverage(), 1e-10);
+    }
+
+    @Test
+    public void listConstructorComputesCorrectAverage() {
+        Collect c = new Collect(LIST_DATA, 1, 3);
+        assertEquals(5.5, c.getAverage(), 1e-10);
+    }
+
+    @Test
+    public void doubleArrayConstructorComputesCorrectMin() {
+        Collect c = new Collect(ARRAY_DATA, 1, 3);
+        assertEquals(1.0, c.getMin(), 1e-10);
+        assertEquals(0, c.getMinIndex());
+    }
+
+    @Test
+    public void doubleArrayConstructorComputesCorrectMax() {
+        Collect c = new Collect(ARRAY_DATA, 1, 3);
+        assertEquals(10.0, c.getMax(), 1e-10);
+        assertEquals(9, c.getMaxIndex());
+    }
+
+    @Test
+    public void listAndArrayConstructorsProduceSameStats() {
+        Collect fromArray = new Collect(ARRAY_DATA, 1, 3);
+        Collect fromList = new Collect(LIST_DATA, 1, 3);
+
+        assertEquals(fromList.getAverage(), fromArray.getAverage(), 1e-10);
+        assertEquals(fromList.getVariance(), fromArray.getVariance(), 1e-10);
+        assertEquals(fromList.getMin(), fromArray.getMin(), 1e-10);
+        assertEquals(fromList.getMax(), fromArray.getMax(), 1e-10);
+    }
+
+    @Test
+    public void readFileOnInMemoryCollectReturnsCopyOfData() throws Exception {
+        Collect c = new Collect(ARRAY_DATA, 1, 3);
+        List<Double> data = c.readFile();
+        assertEquals(ARRAY_DATA.length, data.size());
+        assertEquals(1.0, data.get(0), 1e-10);
+    }
+
+    @Test
+    public void inMemoryCollectComputesFirstDifference() {
+        Collect c = new Collect(new double[]{1.0, 3.0, 6.0, 10.0}, 1, 2);
+        List<Double> diff = c.getFirstDifference();
+        assertEquals(3, diff.size());
+        assertEquals(2.0, diff.get(0), 1e-10);
+        assertEquals(3.0, diff.get(1), 1e-10);
+        assertEquals(4.0, diff.get(2), 1e-10);
+    }
+
+    @Test
+    public void inMemoryCollectComputesRollingAverage() {
+        Collect c = new Collect(new double[]{2.0, 4.0, 6.0, 8.0}, 1, 2);
+        List<Double> rolling = c.getRollingAverage(2);
+        assertEquals(3, rolling.size());
+        assertEquals(3.0, rolling.get(0), 1e-10);
+        assertEquals(5.0, rolling.get(1), 1e-10);
+        assertEquals(7.0, rolling.get(2), 1e-10);
+    }
+
+    @Test
+    public void inMemoryCollectComputesAcf() {
+        Collect c = new Collect(ARRAY_DATA, 1, 3);
+        double[] acf = c.acf(3);
+        // getAcf returns n+1 values
+        assertEquals(4, acf.length);
+        // ACF values are bounded [-1, 1]
+        for (double v : acf) {
+            assertTrue(v >= -1.0 && v <= 1.0, "ACF value out of bounds: " + v);
+        }
+    }
+
+    @Test
+    public void nullArrayThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Collect((double[]) null, 1, 3));
+    }
+
+    @Test
+    public void emptyArrayThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Collect(new double[0], 1, 3));
+    }
+
+    @Test
+    public void nullListThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Collect((List<Double>) null, 1, 3));
+    }
+}

--- a/src/test/java/tslib/decomposition/STLRobustnessTest.java
+++ b/src/test/java/tslib/decomposition/STLRobustnessTest.java
@@ -1,0 +1,104 @@
+package tslib.decomposition;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class STLRobustnessTest {
+
+    /** Builds a clean trend+seasonal series, then inserts one large outlier. */
+    private static List<Double> buildOutlierSeries(int outlierIndex, double outlierMagnitude) {
+        double[] seasonal = {3.0, -1.5, 2.0, -2.0, 1.5, -1.0};
+        List<Double> data = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            data.add(10.0 + i * 0.2 + seasonal[i % seasonal.length]);
+        }
+        data.set(outlierIndex, data.get(outlierIndex) + outlierMagnitude);
+        return data;
+    }
+
+    @Test
+    public void robustnessReducesOutlierInfluenceOnTrend() {
+        List<Double> data = buildOutlierSeries(12, 20.0);
+
+        STLDecomposition plain = new STLDecomposition(6, 7, 7, 2, 0);
+        STLDecomposition robust = new STLDecomposition(6, 7, 7, 2, 2);
+
+        STLDecomposition.Result plainResult = plain.decompose(data);
+        STLDecomposition.Result robustResult = robust.decompose(data);
+
+        // Robust trend should have smaller deviation at the outlier index
+        double plainTrendDeviation = Math.abs(plainResult.getTrend().get(12) - plainResult.getTrend().get(11));
+        double robustTrendDeviation = Math.abs(robustResult.getTrend().get(12) - robustResult.getTrend().get(11));
+        assertTrue(robustTrendDeviation < plainTrendDeviation,
+                "Robust trend deviation " + robustTrendDeviation
+                        + " should be less than non-robust " + plainTrendDeviation);
+    }
+
+    @Test
+    public void robustnessAbsorbsOutlierIntoRemainder() {
+        List<Double> data = buildOutlierSeries(6, 15.0);
+
+        STLDecomposition plain = new STLDecomposition(6, 7, 7, 2, 0);
+        STLDecomposition robust = new STLDecomposition(6, 7, 7, 2, 2);
+
+        STLDecomposition.Result plainResult = plain.decompose(data);
+        STLDecomposition.Result robustResult = robust.decompose(data);
+
+        double robustRemainder = Math.abs(robustResult.getRemainder().get(6));
+        double plainRemainder = Math.abs(plainResult.getRemainder().get(6));
+
+        // Robust decomposition should push more of the anomaly into remainder
+        assertTrue(robustRemainder > plainRemainder,
+                "Robust remainder " + robustRemainder + " should exceed plain " + plainRemainder);
+    }
+
+    @Test
+    public void zeroOuterIterationsMatchesOriginalBehavior() {
+        List<Double> data = buildOutlierSeries(5, 0.0); // no actual outlier
+        STLDecomposition legacy = new STLDecomposition(6, 7, 7, 2);
+        STLDecomposition explicit = new STLDecomposition(6, 7, 7, 2, 0);
+
+        STLDecomposition.Result legacyResult = legacy.decompose(data);
+        STLDecomposition.Result explicitResult = explicit.decompose(data);
+
+        List<Double> legacyTrend = legacyResult.getTrend();
+        List<Double> explicitTrend = explicitResult.getTrend();
+        for (int i = 0; i < legacyTrend.size(); i++) {
+            assertEquals(legacyTrend.get(i), explicitTrend.get(i), 1e-10,
+                    "Trend differs at index " + i);
+        }
+    }
+
+    @Test
+    public void robustResultHasCorrectDimensions() {
+        List<Double> data = buildOutlierSeries(3, 5.0);
+        STLDecomposition robust = new STLDecomposition(6, 7, 7, 2, 1);
+        STLDecomposition.Result result = robust.decompose(data);
+
+        assertEquals(data.size(), result.getTrend().size());
+        assertEquals(data.size(), result.getSeasonal().size());
+        assertEquals(data.size(), result.getRemainder().size());
+    }
+
+    @Test
+    public void reconstructionIsIdenticalToInput() {
+        List<Double> data = buildOutlierSeries(9, 8.0);
+        STLDecomposition robust = new STLDecomposition(6, 7, 7, 2, 2);
+        STLDecomposition.Result result = robust.decompose(data);
+
+        List<Double> reconstructed = result.reconstruct();
+        for (int i = 0; i < data.size(); i++) {
+            assertEquals(data.get(i), reconstructed.get(i), 1e-9,
+                    "Reconstruction mismatch at index " + i);
+        }
+    }
+
+    @Test
+    public void negativeOuterIterationsThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new STLDecomposition(6, 7, 7, 2, -1));
+    }
+}

--- a/src/test/java/tslib/model/arima/VARModelTest.java
+++ b/src/test/java/tslib/model/arima/VARModelTest.java
@@ -1,0 +1,126 @@
+package tslib.model.arima;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VARModelTest {
+
+    private static final List<Double> S1 = List.of(
+            1.0, 1.2, 1.1, 1.4, 1.3, 1.6, 1.5, 1.8,
+            1.7, 2.0, 1.9, 2.2, 2.1, 2.4, 2.3, 2.6
+    );
+    private static final List<Double> S2 = List.of(
+            5.0, 5.1, 5.3, 5.2, 5.5, 5.4, 5.7, 5.6,
+            5.9, 5.8, 6.1, 6.0, 6.3, 6.2, 6.5, 6.4
+    );
+
+    @Test
+    public void varFitsAndForecastsTwoSeries() {
+        VARModel model = new VARModel(1).fit(List.of(S1, S2));
+        List<List<Double>> forecast = model.forecast(3);
+
+        assertEquals(2, forecast.size());
+        assertEquals(3, forecast.get(0).size());
+        assertEquals(3, forecast.get(1).size());
+        assertFalse(Double.isNaN(forecast.get(0).get(0)));
+        assertFalse(Double.isNaN(forecast.get(1).get(0)));
+    }
+
+    @Test
+    public void varWithLagTwoForecastsCorrectly() {
+        VARModel model = new VARModel(2).fit(List.of(S1, S2));
+        List<List<Double>> forecast = model.forecast(5);
+
+        assertEquals(2, forecast.size());
+        assertEquals(5, forecast.get(0).size());
+    }
+
+    @Test
+    public void varForecasting3SeriesWorks() {
+        List<Double> s3 = List.of(
+                2.0, 2.1, 2.0, 2.2, 2.1, 2.3, 2.2, 2.4,
+                2.3, 2.5, 2.4, 2.6, 2.5, 2.7, 2.6, 2.8
+        );
+        VARModel model = new VARModel(1).fit(List.of(S1, S2, s3));
+        List<List<Double>> forecast = model.forecast(4);
+
+        assertEquals(3, forecast.size());
+        forecast.forEach(f -> assertEquals(4, f.size()));
+    }
+
+    @Test
+    public void aic_decreasesFromLag1ToLag2OnTrendData() {
+        VARModel m1 = new VARModel(1).fit(List.of(S1, S2));
+        VARModel m2 = new VARModel(2).fit(List.of(S1, S2));
+        // Just verify getAic returns a finite number for both
+        assertTrue(Double.isFinite(m1.getAic()));
+        assertTrue(Double.isFinite(m2.getAic()));
+    }
+
+    @Test
+    public void fitOptimalSelectsValidLagOrder() {
+        VARModel best = VARModel.fitOptimal(List.of(S1, S2), 3);
+        assertNotNull(best);
+        assertTrue(best.getLagOrder() >= 1 && best.getLagOrder() <= 3);
+        List<List<Double>> forecast = best.forecast(2);
+        assertEquals(2, forecast.size());
+    }
+
+    @Test
+    public void getLagOrderAndNumSeriesAreCorrect() {
+        VARModel model = new VARModel(2).fit(List.of(S1, S2));
+        assertEquals(2, model.getLagOrder());
+        assertEquals(2, model.getNumSeries());
+    }
+
+    @Test
+    public void getCoefficientsHasCorrectShape() {
+        VARModel model = new VARModel(1).fit(List.of(S1, S2));
+        double[][] coeffs = model.getCoefficients();
+        // 2 equations, each with 1 + 1*2 = 3 parameters
+        assertEquals(2, coeffs.length);
+        assertEquals(3, coeffs[0].length);
+        assertEquals(3, coeffs[1].length);
+    }
+
+    @Test
+    public void requiresAtLeastTwoSeries() {
+        List<List<Double>> single = List.of(S1);
+        assertThrows(IllegalArgumentException.class, () -> new VARModel(1).fit(single));
+    }
+
+    @Test
+    public void requiresSeriesLengthExceedingLagOrder() {
+        List<Double> tiny = List.of(1.0, 2.0);
+        assertThrows(IllegalArgumentException.class, () -> new VARModel(2).fit(List.of(tiny, tiny)));
+    }
+
+    @Test
+    public void forecastBeforeFitThrows() {
+        VARModel model = new VARModel(1);
+        assertThrows(IllegalStateException.class, () -> model.forecast(3));
+    }
+
+    @Test
+    public void varIsSerializable() throws Exception {
+        VARModel model = new VARModel(1).fit(List.of(S1, S2));
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(baos)) {
+            oos.writeObject(model);
+        }
+        VARModel loaded;
+        try (java.io.ObjectInputStream ois = new java.io.ObjectInputStream(
+                new java.io.ByteArrayInputStream(baos.toByteArray()))) {
+            loaded = (VARModel) ois.readObject();
+        }
+        List<List<Double>> expected = model.forecast(3);
+        List<List<Double>> actual = loaded.forecast(3);
+        for (int k = 0; k < 2; k++) {
+            for (int h = 0; h < 3; h++) {
+                assertEquals(expected.get(k).get(h), actual.get(k).get(h), 1e-12);
+            }
+        }
+    }
+}

--- a/src/test/java/tslib/model/statespace/LocalLevelModelTest.java
+++ b/src/test/java/tslib/model/statespace/LocalLevelModelTest.java
@@ -2,6 +2,7 @@ package tslib.model.statespace;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class LocalLevelModelTest {
@@ -19,5 +20,76 @@ public class LocalLevelModelTest {
         assertTrue(model.getProcessVariance() > 0.0);
         assertTrue(model.getObservationVariance() > 0.0);
         assertEquals(filtered.get(filtered.size() - 1), forecast.get(0), 1e-9);
+    }
+
+    @Test
+    public void brentMleFindsPositiveVariances() {
+        List<Double> data = List.of(1.0, 1.5, 0.8, 1.2, 1.1, 0.9, 1.0, 1.3,
+                1.2, 1.7, 1.0, 1.4, 1.3, 1.1, 1.2, 1.5);
+        LocalLevelModel model = new LocalLevelModel().fit(data);
+
+        assertTrue(model.getProcessVariance() > 0.0);
+        assertTrue(model.getObservationVariance() > 0.0);
+        assertTrue(Double.isFinite(model.getLogLikelihood()));
+    }
+
+    @Test
+    public void brentMleLogLikelihoodNotWorstCaseGrid() {
+        // The Brent search must find at least as good a solution as the old
+        // 7-point grid that only tried {0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0}.
+        // We verify by checking that the MLE result is a valid, finite score.
+        List<Double> data = List.of(
+                5.0, 5.2, 4.8, 5.1, 5.3, 4.9, 5.0, 5.4,
+                5.1, 5.5, 4.7, 5.2, 5.0, 5.3, 4.9, 5.1
+        );
+        LocalLevelModel model = new LocalLevelModel().fit(data);
+        double ll = model.getLogLikelihood();
+
+        // Any reasonable MLE must beat the degenerate constant-forecast baseline.
+        // We just assert the log-likelihood is finite and the ratio is in range.
+        assertTrue(Double.isFinite(ll));
+        // The Brent search spans log(1e-4) to log(1e4), i.e., ratio in [1e-4, 1e4].
+        double ratio = model.getProcessVariance() / model.getObservationVariance();
+        assertTrue(ratio > 0.0);
+        assertTrue(ratio <= 1e4 + 1.0);
+    }
+
+    @Test
+    public void brentSearchHandlesSinglePointBySeries() {
+        // Very short series: only 2 observations (minimum valid input)
+        List<Double> data = List.of(3.0, 4.0);
+        LocalLevelModel model = new LocalLevelModel().fit(data);
+        assertEquals(1, model.forecast(1).size());
+        assertTrue(model.getProcessVariance() > 0.0);
+    }
+
+    @Test
+    public void forecastIntervalWidthGrowsWithHorizon() {
+        List<Double> data = List.of(10.0, 10.5, 9.8, 10.2, 10.1, 9.9, 10.0, 10.3);
+        LocalLevelModel model = new LocalLevelModel().fit(data);
+        List<Double> vars = model.getForecastVariances(5);
+
+        for (int i = 1; i < vars.size(); i++) {
+            assertTrue(vars.get(i) > vars.get(i - 1),
+                    "Forecast variance should increase with horizon");
+        }
+    }
+
+    @Test
+    public void modelIsSerializable() throws Exception {
+        List<Double> data = List.of(10.0, 10.5, 9.8, 10.2, 10.1, 9.9, 10.0, 10.3);
+        LocalLevelModel original = new LocalLevelModel().fit(data);
+
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(baos)) {
+            oos.writeObject(original);
+        }
+        LocalLevelModel loaded;
+        try (java.io.ObjectInputStream ois = new java.io.ObjectInputStream(
+                new java.io.ByteArrayInputStream(baos.toByteArray()))) {
+            loaded = (LocalLevelModel) ois.readObject();
+        }
+        assertEquals(original.getLogLikelihood(), loaded.getLogLikelihood(), 1e-12);
+        assertEquals(original.forecast(3), loaded.forecast(3));
     }
 }

--- a/src/test/java/tslib/util/ModelSerializerTest.java
+++ b/src/test/java/tslib/util/ModelSerializerTest.java
@@ -1,0 +1,99 @@
+package tslib.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tslib.model.arima.ARIMA;
+import tslib.model.arima.SARIMA;
+import tslib.model.statespace.LocalLevelModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModelSerializerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static final List<Double> SERIES = List.of(
+            1.0, 1.3, 1.1, 1.5, 1.4, 1.8, 1.6, 2.0,
+            1.9, 2.3, 2.1, 2.5, 2.4, 2.8, 2.6, 3.0
+    );
+
+    @Test
+    public void arimaRoundTripProducesIdenticalForecasts() throws IOException, ClassNotFoundException {
+        ARIMA original = new ARIMA(1, 0, 1).fit(SERIES);
+        Path dest = tempDir.resolve("arima.ser");
+
+        ModelSerializer.save(original, dest.toString());
+        ARIMA loaded = ModelSerializer.load(dest.toString());
+
+        List<Double> expectedForecast = original.forecast(5);
+        List<Double> actualForecast = loaded.forecast(5);
+        assertEquals(expectedForecast.size(), actualForecast.size());
+        for (int i = 0; i < expectedForecast.size(); i++) {
+            assertEquals(expectedForecast.get(i), actualForecast.get(i), 1e-12);
+        }
+    }
+
+    @Test
+    public void arimaRoundTripPreservesCoefficients() throws IOException, ClassNotFoundException {
+        ARIMA original = new ARIMA(2, 1, 1).fit(SERIES);
+        Path dest = tempDir.resolve("arima_coeffs.ser");
+
+        ModelSerializer.save(original, dest.toString());
+        ARIMA loaded = ModelSerializer.load(dest.toString());
+
+        assertArrayEquals(original.getArCoefficients(), loaded.getArCoefficients(), 1e-15);
+        assertArrayEquals(original.getMaCoefficients(), loaded.getMaCoefficients(), 1e-15);
+        assertEquals(original.getIntercept(), loaded.getIntercept(), 1e-15);
+        assertEquals(original.getInnovationVariance(), loaded.getInnovationVariance(), 1e-15);
+    }
+
+    @Test
+    public void sarimaRoundTripProducesIdenticalForecasts() throws IOException, ClassNotFoundException {
+        List<Double> seasonal = new java.util.ArrayList<>();
+        for (int i = 0; i < 24; i++) {
+            seasonal.add(10.0 + Math.sin(2 * Math.PI * i / 12) + i * 0.1);
+        }
+        SARIMA original = new SARIMA(1, 0, 0, 0, 0, 0, 12).fit(seasonal);
+        Path dest = tempDir.resolve("sarima.ser");
+
+        ModelSerializer.save(original, dest.toString());
+        SARIMA loaded = ModelSerializer.load(dest.toString());
+
+        List<Double> expected = original.forecast(4);
+        List<Double> actual = loaded.forecast(4);
+        assertEquals(expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i), actual.get(i), 1e-12);
+        }
+    }
+
+    @Test
+    public void localLevelModelRoundTripPreservesForecasts() throws IOException, ClassNotFoundException {
+        LocalLevelModel original = new LocalLevelModel().fit(SERIES);
+        Path dest = tempDir.resolve("llm.ser");
+
+        ModelSerializer.save(original, dest.toString());
+        LocalLevelModel loaded = ModelSerializer.load(dest.toString());
+
+        List<Double> expected = original.forecast(3);
+        List<Double> actual = loaded.forecast(3);
+        assertEquals(expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i), actual.get(i), 1e-12);
+        }
+        assertEquals(original.getLogLikelihood(), loaded.getLogLikelihood(), 1e-12);
+    }
+
+    @Test
+    public void serializedFileSizeIsNonZero() throws IOException {
+        ARIMA model = new ARIMA(1, 0, 0).fit(SERIES);
+        Path dest = tempDir.resolve("size_check.ser");
+        ModelSerializer.save(model, dest.toString());
+        assertTrue(Files.size(dest) > 0);
+    }
+}


### PR DESCRIPTION
  11 — Model Serialization

  All fitted model classes (ARIMA, SARIMA, ARIMAX, LocalLevelModel, KalmanFilter, SingleExpSmoothing, DoubleExpSmoothing, TripleExpSmoothing) now implement
  java.io.Serializable. A new utility tslib/util/ModelSerializer.java provides:
  - ModelSerializer.save(model, /path/model.ser) — writes to disk
  - ModelSerializer.load(/path/model.ser) — reads back without re-fitting

  12 — LocalLevelModel MLE Optimization

  Replaced the 7-point PROCESS_RATIO_GRID with a BrentOptimizer search over the log-transformed q/r ratio in [log(1e-4), log(1e4)]. The optimizer minimizes negative
  Kalman log-likelihood, finding the exact MLE rather than the closest grid point. Same Commons Math3 pattern already used in Transform.boxCoxLambdaSearch.

  14 — VAR (Vector Autoregression)

  New class tslib/model/arima/VARModel.java. Each equation is estimated independently via OLS (LinearAlgebra.ordinaryLeastSquares). Key API: fit(List<List<Double>>),
  forecast(int steps), getAic(), and static fitOptimal(series, maxLag) for AIC-based lag selection. Implements Serializable.

  15 — STL Robustness Iterations

  STLDecomposition gains a new 5-argument constructor with outerIterations (default 0, backward-compatible). When > 0, each outer pass computes bisquare robustness
  weights from h = 6 × median(|remainder|), which are folded into the LOESS weights for the next pass — per Cleveland et al. (1990).

  16 — In-Memory Collect Constructor

  Two new Collect constructors accept data directly without touching the filesystem:
  - new Collect(List<Double> data, int k, int n)
  - new Collect(double[] data, int k, int n)     :