### PR TITLE
REST layer prep

### DIFF
--- a/src/main/java/tslib/model/TimeSeriesModel.java
+++ b/src/main/java/tslib/model/TimeSeriesModel.java
@@ -1,0 +1,26 @@
+package tslib.model;
+
+import java.io.Serializable;
+import java.util.List;
+import tslib.evaluation.IntervalForecast;
+
+/**
+ * Common contract for all univariate time-series forecasting models.
+ *
+ * <p>Implementors follow a two-step workflow:
+ * <pre>
+ *   model.fit(data).forecast(steps)
+ *   model.fit(data).forecastWithIntervals(steps, 0.95)
+ * </pre>
+ *
+ * <p>Calling {@link #forecast} or {@link #forecastWithIntervals} before {@link #fit}
+ * must throw {@link IllegalStateException}.
+ */
+public interface TimeSeriesModel extends Serializable {
+
+    TimeSeriesModel fit(List<Double> data);
+
+    List<Double> forecast(int steps);
+
+    IntervalForecast forecastWithIntervals(int steps, double confidenceLevel);
+}

--- a/src/main/java/tslib/model/TripleExpSmoothing.java
+++ b/src/main/java/tslib/model/TripleExpSmoothing.java
@@ -1,6 +1,11 @@
 package tslib.model;
 
 public class TripleExpSmoothing extends tslib.model.expsmoothing.TripleExpSmoothing implements ExponentialSmoothing {
+
+    public TripleExpSmoothing(double alpha, double beta, double gamma, int period) {
+        super(alpha, beta, gamma, period);
+    }
+
     public TripleExpSmoothing(double alpha, double beta, double gamma, int period, boolean debug) {
         super(alpha, beta, gamma, period, debug);
     }

--- a/src/main/java/tslib/model/arima/ARIMA.java
+++ b/src/main/java/tslib/model/arima/ARIMA.java
@@ -1,6 +1,5 @@
 package tslib.model.arima;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,7 +15,7 @@ import tslib.util.LinearAlgebra;
  * This implementation is intentionally small and dependency-light. It supports manual order
  * selection and is designed for straightforward forecasting workflows inside this library.
  */
-public class ARIMA implements Serializable {
+public class ARIMA implements tslib.model.TimeSeriesModel {
 
     private static final long serialVersionUID = 1L;
     private static final double DEFAULT_RIDGE = 1e-6;

--- a/src/main/java/tslib/model/arima/SARIMA.java
+++ b/src/main/java/tslib/model/arima/SARIMA.java
@@ -1,6 +1,5 @@
 package tslib.model.arima;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +16,7 @@ import tslib.util.LinearAlgebra;
  * dependency-light, and easy to reason about. Seasonal AR and MA terms are fitted together with
  * the non-seasonal terms after applying the requested regular and seasonal differencing.
  */
-public class SARIMA implements Serializable {
+public class SARIMA implements tslib.model.TimeSeriesModel {
 
     private static final long serialVersionUID = 1L;
     private static final double DEFAULT_RIDGE = 1e-6;

--- a/src/main/java/tslib/model/expsmoothing/DoubleExpSmoothing.java
+++ b/src/main/java/tslib/model/expsmoothing/DoubleExpSmoothing.java
@@ -3,10 +3,9 @@ package tslib.model.expsmoothing;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import tslib.evaluation.ForecastIntervals;
+import tslib.evaluation.IntervalForecast;
 
-/**
- * Double Exponential Smoothing (Holt's Linear Trend Method).
- */
 public class DoubleExpSmoothing implements ExponentialSmoothing, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -14,6 +13,11 @@ public class DoubleExpSmoothing implements ExponentialSmoothing, Serializable {
     private final double alpha;
     private final double gamma;
     private final int initializationMethod;
+
+    private boolean fitted;
+    private double lastLevel;
+    private double lastTrend;
+    private List<Double> residuals;
 
     public DoubleExpSmoothing(double alpha, double gamma, int initializationMethod) {
         if (alpha <= 0 || alpha > 1 || gamma <= 0 || gamma > 1) {
@@ -28,39 +32,90 @@ public class DoubleExpSmoothing implements ExponentialSmoothing, Serializable {
     }
 
     @Override
-    public List<Double> forecast(List<Double> data, int steps) {
+    public DoubleExpSmoothing fit(List<Double> data) {
         if (data == null || data.size() < 2) {
             throw new IllegalArgumentException("Data must contain at least 2 points.");
         }
-
         int n = data.size();
-        double[] y = new double[n + steps];
         double[] s = new double[n];
         double[] b = new double[n];
-
         s[0] = data.get(0);
         switch (initializationMethod) {
             case 0 -> b[0] = data.get(1) - data.get(0);
             case 1 -> b[0] = (n > 4) ? (data.get(3) - data.get(0)) / 3 : data.get(1) - data.get(0);
             case 2 -> b[0] = (data.get(n - 1) - data.get(0)) / (n - 1);
         }
+        List<Double> res = new ArrayList<>(n - 1);
+        for (int i = 1; i < n; i++) {
+            double predicted = s[i - 1] + b[i - 1];
+            res.add(data.get(i) - predicted);
+            s[i] = alpha * data.get(i) + (1 - alpha) * predicted;
+            b[i] = gamma * (s[i] - s[i - 1]) + (1 - gamma) * b[i - 1];
+        }
+        this.lastLevel = s[n - 1];
+        this.lastTrend = b[n - 1];
+        this.residuals = res;
+        this.fitted = true;
+        return this;
+    }
 
+    @Override
+    public List<Double> forecast(int steps) {
+        requireFitted();
+        if (steps < 0) {
+            throw new IllegalArgumentException("Steps must be >= 0");
+        }
+        List<Double> result = new ArrayList<>(steps);
+        for (int h = 1; h <= steps; h++) {
+            result.add(lastLevel + h * lastTrend);
+        }
+        return result;
+    }
+
+    @Override
+    public IntervalForecast forecastWithIntervals(int steps, double confidenceLevel) {
+        requireFitted();
+        List<Double> fc = forecast(steps);
+        double mse = residuals.isEmpty() ? 1.0
+                : residuals.stream().mapToDouble(e -> e * e).average().orElse(1.0);
+        return ForecastIntervals.wrap(fc,
+                ForecastIntervals.normalIntervals(fc, mse, confidenceLevel, true));
+    }
+
+    @Override
+    public List<Double> forecast(List<Double> data, int steps) {
+        if (data == null || data.size() < 2) {
+            throw new IllegalArgumentException("Data must contain at least 2 points.");
+        }
+        int n = data.size();
+        double[] y = new double[n + steps];
+        double[] s = new double[n];
+        double[] b = new double[n];
+        s[0] = data.get(0);
+        switch (initializationMethod) {
+            case 0 -> b[0] = data.get(1) - data.get(0);
+            case 1 -> b[0] = (n > 4) ? (data.get(3) - data.get(0)) / 3 : data.get(1) - data.get(0);
+            case 2 -> b[0] = (data.get(n - 1) - data.get(0)) / (n - 1);
+        }
         y[0] = s[0] + b[0];
-
         for (int i = 1; i < n; i++) {
             s[i] = alpha * data.get(i) + (1 - alpha) * (s[i - 1] + b[i - 1]);
             b[i] = gamma * (s[i] - s[i - 1]) + (1 - gamma) * b[i - 1];
             y[i] = s[i] + b[i];
         }
-
         for (int j = 0; j < steps; j++) {
             y[n + j] = s[n - 1] + (j + 1) * b[n - 1];
         }
-
-        List<Double> forecast = new ArrayList<>(y.length);
+        List<Double> result = new ArrayList<>(y.length);
         for (double v : y) {
-            forecast.add(v);
+            result.add(v);
         }
-        return forecast;
+        return result;
+    }
+
+    private void requireFitted() {
+        if (!fitted) {
+            throw new IllegalStateException("Model must be fitted before forecasting");
+        }
     }
 }

--- a/src/main/java/tslib/model/expsmoothing/ExponentialSmoothing.java
+++ b/src/main/java/tslib/model/expsmoothing/ExponentialSmoothing.java
@@ -1,14 +1,23 @@
 package tslib.model.expsmoothing;
 
 import java.util.List;
+import tslib.evaluation.IntervalForecast;
+import tslib.model.TimeSeriesModel;
 
-public interface ExponentialSmoothing {
+public interface ExponentialSmoothing extends TimeSeriesModel {
+
+    /** Fit the model and return {@code this} for chaining. */
+    ExponentialSmoothing fit(List<Double> data);
+
+    /** Forecast {@code steps} future values from the fitted model. */
+    List<Double> forecast(int steps);
+
+    /** Forecast with prediction intervals from the fitted model. */
+    IntervalForecast forecastWithIntervals(int steps, double confidenceLevel);
+
     /**
-     * Forecasts values based on time series data.
-     *
-     * @param data the time series input
-     * @param steps number of future periods to forecast
-     * @return list of forecasted values (original data + forecast)
+     * Stateless convenience: fit on {@code data} then return in-sample fitted values
+     * followed by {@code steps} future forecasts.
      */
     List<Double> forecast(List<Double> data, int steps);
 }

--- a/src/main/java/tslib/model/expsmoothing/SingleExpSmoothing.java
+++ b/src/main/java/tslib/model/expsmoothing/SingleExpSmoothing.java
@@ -3,15 +3,18 @@ package tslib.model.expsmoothing;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import tslib.evaluation.ForecastIntervals;
+import tslib.evaluation.IntervalForecast;
 
-/**
- * Single Exponential Smoothing implementation.
- */
 public class SingleExpSmoothing implements ExponentialSmoothing, Serializable {
 
     private static final long serialVersionUID = 1L;
 
     private final double alpha;
+
+    private boolean fitted;
+    private double lastSmoothed;
+    private List<Double> residuals;
 
     public SingleExpSmoothing(double alpha) {
         if (alpha <= 0 || alpha > 1) {
@@ -21,29 +24,68 @@ public class SingleExpSmoothing implements ExponentialSmoothing, Serializable {
     }
 
     @Override
+    public SingleExpSmoothing fit(List<Double> data) {
+        if (data == null || data.isEmpty()) {
+            throw new IllegalArgumentException("Input data must not be null or empty.");
+        }
+        int n = data.size();
+        double smoothed = data.get(0);
+        List<Double> res = new ArrayList<>(n - 1);
+        for (int i = 1; i < n; i++) {
+            res.add(data.get(i) - smoothed);
+            smoothed = alpha * data.get(i) + (1 - alpha) * smoothed;
+        }
+        this.lastSmoothed = smoothed;
+        this.residuals = res;
+        this.fitted = true;
+        return this;
+    }
+
+    @Override
+    public List<Double> forecast(int steps) {
+        requireFitted();
+        if (steps < 0) {
+            throw new IllegalArgumentException("Steps must be >= 0");
+        }
+        List<Double> result = new ArrayList<>(steps);
+        for (int i = 0; i < steps; i++) {
+            result.add(lastSmoothed);
+        }
+        return result;
+    }
+
+    @Override
+    public IntervalForecast forecastWithIntervals(int steps, double confidenceLevel) {
+        requireFitted();
+        List<Double> fc = forecast(steps);
+        double mse = residuals.isEmpty() ? 1.0
+                : residuals.stream().mapToDouble(e -> e * e).average().orElse(1.0);
+        return ForecastIntervals.wrap(fc,
+                ForecastIntervals.normalIntervals(fc, mse, confidenceLevel, true));
+    }
+
+    @Override
     public List<Double> forecast(List<Double> data, int steps) {
         if (data == null || data.isEmpty()) {
             throw new IllegalArgumentException("Input data must not be null or empty.");
         }
-
         int n = data.size();
         List<Double> result = new ArrayList<>(n + steps);
-
-        // Initialize first smoothed value
         double smoothed = data.get(0);
         result.add(smoothed);
-
-        // Apply smoothing to historical data
         for (int i = 1; i < n; i++) {
             smoothed = alpha * data.get(i) + (1 - alpha) * smoothed;
             result.add(smoothed);
         }
-
-        // Forecast future values using last smoothed value
         for (int i = 0; i < steps; i++) {
             result.add(smoothed);
         }
-
         return result;
+    }
+
+    private void requireFitted() {
+        if (!fitted) {
+            throw new IllegalStateException("Model must be fitted before forecasting");
+        }
     }
 }

--- a/src/main/java/tslib/model/expsmoothing/TripleExpSmoothing.java
+++ b/src/main/java/tslib/model/expsmoothing/TripleExpSmoothing.java
@@ -3,10 +3,9 @@ package tslib.model.expsmoothing;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import tslib.evaluation.ForecastIntervals;
+import tslib.evaluation.IntervalForecast;
 
-/**
- * Triple Exponential Smoothing (Holt-Winters Multiplicative Method).
- */
 public class TripleExpSmoothing implements ExponentialSmoothing, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -15,7 +14,16 @@ public class TripleExpSmoothing implements ExponentialSmoothing, Serializable {
     private final double beta;
     private final double gamma;
     private final int period;
-    private final boolean debug;
+
+    private boolean fitted;
+    private double lastLevel;
+    private double lastTrend;
+    private List<Double> lastSeasonalIndices;
+    private List<Double> residuals;
+
+    public TripleExpSmoothing(double alpha, double beta, double gamma, int period) {
+        this(alpha, beta, gamma, period, false);
+    }
 
     public TripleExpSmoothing(double alpha, double beta, double gamma, int period, boolean debug) {
         if (alpha < 0.0 || alpha > 1.0 || beta < 0.0 || beta > 1.0 || gamma < 0.0 || gamma > 1.0) {
@@ -28,7 +36,82 @@ public class TripleExpSmoothing implements ExponentialSmoothing, Serializable {
         this.beta = beta;
         this.gamma = gamma;
         this.period = period;
-        this.debug = debug;
+    }
+
+    @Override
+    public TripleExpSmoothing fit(List<Double> data) {
+        if (data == null || data.size() < 2 * period) {
+            throw new IllegalArgumentException(
+                    "Data must contain at least 2 complete seasonal cycles (2 * period = " + (2 * period) + ").");
+        }
+        int n = data.size();
+        int seasons = n / period;
+        double b0 = calculateInitialTrend(data, period);
+        List<Double> seasonal = calculateSeasonalIndices(data, period, seasons);
+
+        double[] St = new double[n];
+        double[] Bt = new double[n];
+        double[] It = new double[n];
+
+        for (int i = 0; i < period && i < n; i++) {
+            It[i] = seasonal.get(i);
+        }
+        for (int i = period; i < n; i++) {
+            It[i] = 1.0;
+        }
+        St[1] = data.get(0);
+        Bt[1] = b0;
+
+        List<Double> res = new ArrayList<>();
+        for (int i = 2; i < n; i++) {
+            if (i - period >= 0) {
+                St[i] = alpha * data.get(i) / It[i - period] + (1 - alpha) * (St[i - 1] + Bt[i - 1]);
+            } else {
+                St[i] = alpha * data.get(i) + (1 - alpha) * (St[i - 1] + Bt[i - 1]);
+            }
+            Bt[i] = gamma * (St[i] - St[i - 1]) + (1 - gamma) * Bt[i - 1];
+            if (i - period >= 0) {
+                It[i] = beta * data.get(i) / St[i] + (1 - beta) * It[i - period];
+            }
+            if (i >= period + 1 && It[i - period] != 0) {
+                double onestep = (St[i - 1] + Bt[i - 1]) * It[i - period];
+                res.add(data.get(i) - onestep);
+            }
+        }
+
+        this.lastLevel = St[n - 1];
+        this.lastTrend = Bt[n - 1];
+        this.lastSeasonalIndices = new ArrayList<>(period);
+        for (int i = n - period; i < n; i++) {
+            lastSeasonalIndices.add(It[i]);
+        }
+        this.residuals = res;
+        this.fitted = true;
+        return this;
+    }
+
+    @Override
+    public List<Double> forecast(int steps) {
+        requireFitted();
+        if (steps < 0) {
+            throw new IllegalArgumentException("Steps must be >= 0");
+        }
+        List<Double> result = new ArrayList<>(steps);
+        for (int h = 1; h <= steps; h++) {
+            double seasonal = lastSeasonalIndices.get((h - 1) % period);
+            result.add((lastLevel + h * lastTrend) * seasonal);
+        }
+        return result;
+    }
+
+    @Override
+    public IntervalForecast forecastWithIntervals(int steps, double confidenceLevel) {
+        requireFitted();
+        List<Double> fc = forecast(steps);
+        double mse = residuals.isEmpty() ? 1.0
+                : residuals.stream().mapToDouble(e -> e * e).average().orElse(1.0);
+        return ForecastIntervals.wrap(fc,
+                ForecastIntervals.normalIntervals(fc, mse, confidenceLevel, true));
     }
 
     @Override
@@ -36,7 +119,6 @@ public class TripleExpSmoothing implements ExponentialSmoothing, Serializable {
         if (y == null || y.isEmpty()) {
             throw new IllegalArgumentException("Input time series must not be null or empty.");
         }
-
         int n = y.size();
         int seasons = n / period;
         double a0 = y.get(0);
@@ -64,24 +146,14 @@ public class TripleExpSmoothing implements ExponentialSmoothing, Serializable {
             } else {
                 St.set(i, alpha * y.get(i) + (1 - alpha) * (St.get(i - 1) + Bt.get(i - 1)));
             }
-
             Bt.set(i, gamma * (St.get(i) - St.get(i - 1)) + (1 - gamma) * Bt.get(i - 1));
-
             if (i - period >= 0) {
                 It.set(i, beta * y.get(i) / St.get(i) + (1 - beta) * It.get(i - period));
             }
-
             if (i + m < Ft.size() && (i - period + m) >= 0 && (i - period + m) < It.size()) {
                 Ft.set(i + m, (St.get(i) + m * Bt.get(i)) * It.get(i - period + m));
             }
-
-            if (debug) {
-                System.out.printf("i = %d, y = %.2f, S = %.4f, Bt = %.4f, It = %.4f, F = %.4f%n",
-                        i, y.get(i), St.get(i), Bt.get(i), It.get(i),
-                        (i + m < Ft.size()) ? Ft.get(i + m) : 0.0);
-            }
         }
-
         return Ft;
     }
 
@@ -104,22 +176,25 @@ public class TripleExpSmoothing implements ExponentialSmoothing, Serializable {
             }
             seasonalAverages[i] /= period;
         }
-
         for (int i = 0; i < seasons; i++) {
             for (int j = 0; j < period; j++) {
                 normalized[i * period + j] = y.get(i * period + j) / seasonalAverages[i];
             }
         }
-
         for (int i = 0; i < period; i++) {
             for (int j = 0; j < seasons; j++) {
                 seasonalIndices[i] += normalized[j * period + i];
             }
             seasonalIndices[i] /= seasons;
         }
-
         List<Double> result = new ArrayList<>();
         for (double val : seasonalIndices) result.add(val);
         return result;
+    }
+
+    private void requireFitted() {
+        if (!fitted) {
+            throw new IllegalStateException("Model must be fitted before forecasting");
+        }
     }
 }

--- a/src/main/java/tslib/model/statespace/LocalLevelModel.java
+++ b/src/main/java/tslib/model/statespace/LocalLevelModel.java
@@ -1,6 +1,5 @@
 package tslib.model.statespace;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.math3.analysis.UnivariateFunction;
@@ -21,7 +20,7 @@ import tslib.evaluation.PredictionInterval;
  * over a log-transformed ratio search interval, using the Brent algorithm (exact MLE
  * rather than a 7-point grid).
  */
-public class LocalLevelModel implements Serializable {
+public class LocalLevelModel implements tslib.model.TimeSeriesModel {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/tslib/selection/AutoArima.java
+++ b/src/main/java/tslib/selection/AutoArima.java
@@ -1,6 +1,8 @@
 package tslib.selection;
 
 import java.util.List;
+import tslib.evaluation.IntervalForecast;
+import tslib.model.TimeSeriesModel;
 import tslib.model.arima.ARIMA;
 import tslib.model.arima.ArimaOrderSearch;
 import tslib.model.arima.SARIMA;
@@ -8,7 +10,9 @@ import tslib.model.arima.SARIMA;
 /**
  * Small convenience wrapper around the manual order-search helpers.
  */
-public class AutoArima {
+public class AutoArima implements TimeSeriesModel {
+
+    private static final long serialVersionUID = 1L;
 
     private final int maxP;
     private final int maxD;
@@ -78,6 +82,13 @@ public class AutoArima {
     public List<Double> forecast(int steps) {
         requireFit();
         return sarima != null ? sarima.forecast(steps) : arima.forecast(steps);
+    }
+
+    public IntervalForecast forecastWithIntervals(int steps, double confidenceLevel) {
+        requireFit();
+        return sarima != null
+                ? sarima.forecastWithIntervals(steps, confidenceLevel)
+                : arima.forecastWithIntervals(steps, confidenceLevel);
     }
 
     public ArimaOrderSearch.OrderScore getBestOrder() {

--- a/src/main/java/tslib/selection/AutoETS.java
+++ b/src/main/java/tslib/selection/AutoETS.java
@@ -9,7 +9,9 @@ import org.apache.commons.math3.optim.univariate.BrentOptimizer;
 import org.apache.commons.math3.optim.univariate.SearchInterval;
 import org.apache.commons.math3.optim.univariate.UnivariateObjectiveFunction;
 import org.apache.commons.math3.optim.univariate.UnivariatePointValuePair;
+import tslib.evaluation.IntervalForecast;
 import tslib.evaluation.RollingOriginBacktest;
+import tslib.model.TimeSeriesModel;
 import tslib.model.expsmoothing.DoubleExpSmoothing;
 import tslib.model.expsmoothing.ExponentialSmoothing;
 import tslib.model.expsmoothing.SingleExpSmoothing;
@@ -20,7 +22,9 @@ import tslib.model.expsmoothing.TripleExpSmoothing;
  * Uses Brent's method with coordinate descent instead of a coarse grid search,
  * giving precise parameter estimates over the continuous [0.01, 0.99] domain.
  */
-public class AutoETS {
+public class AutoETS implements TimeSeriesModel {
+
+    private static final long serialVersionUID = 1L;
 
     public enum ModelType {
         SINGLE,
@@ -38,6 +42,7 @@ public class AutoETS {
     private double[] bestParameters;
     private double bestScore = Double.POSITIVE_INFINITY;
     private ExponentialSmoothing bestModel;
+    private ExponentialSmoothing fittedBestModel;
     private List<Double> trainingData;
 
     public AutoETS() {
@@ -145,12 +150,18 @@ public class AutoETS {
                     backtest.run(data, tesBest::forecast).getRmse());
         }
 
+        fittedBestModel = bestModel.fit(trainingData);
         return this;
     }
 
     public List<Double> forecast(int steps) {
         requireFit();
-        return bestModel.forecast(trainingData, steps).subList(trainingData.size(), trainingData.size() + steps);
+        return fittedBestModel.forecast(steps);
+    }
+
+    public IntervalForecast forecastWithIntervals(int steps, double confidenceLevel) {
+        requireFit();
+        return fittedBestModel.forecastWithIntervals(steps, confidenceLevel);
     }
 
     public ModelType getBestType() {

--- a/src/test/java/tslib/evaluation/BacktestResultTest.java
+++ b/src/test/java/tslib/evaluation/BacktestResultTest.java
@@ -1,0 +1,79 @@
+package tslib.evaluation;
+
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BacktestResultTest {
+
+    private static final List<Double> ACTUAL   = List.of(10.0, 20.0, 30.0);
+    private static final List<Double> FORECAST = List.of(11.0, 19.0, 31.0);
+    private static final List<Integer> ORIGINS = List.of(0, 1, 2);
+    private static final List<Double> FULL     = List.of(5.0, 7.0, 10.0, 20.0, 30.0);
+    private static final int PERIOD = 1;
+
+    private BacktestResult build() {
+        return new BacktestResult(ACTUAL, FORECAST, ORIGINS, FULL, PERIOD);
+    }
+
+    @Test
+    public void getMaeIsCorrect() {
+        assertEquals(1.0, build().getMae(), 1e-9);
+    }
+
+    @Test
+    public void getRmseIsCorrect() {
+        assertEquals(1.0, build().getRmse(), 1e-9);
+    }
+
+    @Test
+    public void getMapeIsPositive() {
+        assertTrue(build().getMape() > 0.0);
+    }
+
+    @Test
+    public void getSmapeIsPositive() {
+        assertTrue(build().getSmape() > 0.0);
+    }
+
+    @Test
+    public void getMaseIsPositive() {
+        assertTrue(build().getMase() > 0.0);
+    }
+
+    @Test
+    public void getActualReturnsDefensiveCopy() {
+        BacktestResult result = build();
+        result.getActual().add(99.0);
+        assertEquals(3, result.getActual().size());
+    }
+
+    @Test
+    public void getForecastReturnsDefensiveCopy() {
+        BacktestResult result = build();
+        result.getForecast().add(99.0);
+        assertEquals(3, result.getForecast().size());
+    }
+
+    @Test
+    public void getOriginsReturnsDefensiveCopy() {
+        BacktestResult result = build();
+        result.getOrigins().add(99);
+        assertEquals(3, result.getOrigins().size());
+    }
+
+    @Test
+    public void constructorIsDefensiveOverInputLists() {
+        List<Double> actual = new ArrayList<>(ACTUAL);
+        BacktestResult result = new BacktestResult(actual, FORECAST, ORIGINS, FULL, PERIOD);
+        actual.add(99.0);
+        assertEquals(3, result.getActual().size());
+    }
+
+    @Test
+    public void perfectForecastHasZeroMae() {
+        BacktestResult r = new BacktestResult(ACTUAL, ACTUAL, ORIGINS, FULL, PERIOD);
+        assertEquals(0.0, r.getMae(), 1e-15);
+    }
+}

--- a/src/test/java/tslib/evaluation/BenchmarkSummaryTest.java
+++ b/src/test/java/tslib/evaluation/BenchmarkSummaryTest.java
@@ -1,0 +1,55 @@
+package tslib.evaluation;
+
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BenchmarkSummaryTest {
+
+    private BenchmarkSummary direct() {
+        return new BenchmarkSummary("ModelA", 1.0, 2.0, 3.0, 4.0, 5.0);
+    }
+
+    @Test
+    public void gettersReturnConstructorValues() {
+        BenchmarkSummary s = direct();
+        assertEquals("ModelA", s.getModelName());
+        assertEquals(1.0, s.getMae(), 1e-15);
+        assertEquals(2.0, s.getRmse(), 1e-15);
+        assertEquals(3.0, s.getMape(), 1e-15);
+        assertEquals(4.0, s.getSmape(), 1e-15);
+        assertEquals(5.0, s.getMase(), 1e-15);
+    }
+
+    @Test
+    public void constructFromBacktestResult() {
+        List<Double> actual   = List.of(10.0, 20.0, 30.0);
+        List<Double> forecast = List.of(11.0, 19.0, 31.0);
+        BacktestResult result = new BacktestResult(
+                actual, forecast, List.of(0, 1, 2),
+                List.of(5.0, 7.0, 10.0, 20.0, 30.0), 1);
+
+        BenchmarkSummary s = new BenchmarkSummary("TestModel", result);
+        assertEquals("TestModel", s.getModelName());
+        assertEquals(result.getMae(),   s.getMae(),   1e-15);
+        assertEquals(result.getRmse(),  s.getRmse(),  1e-15);
+        assertEquals(result.getMape(),  s.getMape(),  1e-15);
+        assertEquals(result.getSmape(), s.getSmape(), 1e-15);
+        assertEquals(result.getMase(),  s.getMase(),  1e-15);
+    }
+
+    @Test
+    public void compareToSortsByRmseAscending() {
+        BenchmarkSummary better = new BenchmarkSummary("A", 1.0, 1.0, 1.0, 1.0, 1.0);
+        BenchmarkSummary worse  = new BenchmarkSummary("B", 1.0, 5.0, 1.0, 1.0, 1.0);
+        assertTrue(better.compareTo(worse) < 0);
+        assertTrue(worse.compareTo(better) > 0);
+    }
+
+    @Test
+    public void compareToEqualRmseReturnsZero() {
+        BenchmarkSummary a = new BenchmarkSummary("A", 1.0, 2.0, 3.0, 4.0, 5.0);
+        BenchmarkSummary b = new BenchmarkSummary("B", 9.0, 2.0, 9.0, 9.0, 9.0);
+        assertEquals(0, a.compareTo(b));
+    }
+}

--- a/src/test/java/tslib/evaluation/IntervalForecastTest.java
+++ b/src/test/java/tslib/evaluation/IntervalForecastTest.java
@@ -1,0 +1,88 @@
+package tslib.evaluation;
+
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IntervalForecastTest {
+
+    private static List<Double> forecasts() {
+        return new ArrayList<>(List.of(10.0, 11.0, 12.0));
+    }
+
+    private static List<PredictionInterval> intervals() {
+        return new ArrayList<>(List.of(
+                new PredictionInterval(1, 10.0, 8.0, 12.0, 0.95),
+                new PredictionInterval(2, 11.0, 8.5, 13.5, 0.95),
+                new PredictionInterval(3, 12.0, 9.0, 15.0, 0.95)));
+    }
+
+    @Test
+    public void getForecastsReturnsAllValues() {
+        IntervalForecast f = new IntervalForecast(forecasts(), intervals());
+        assertEquals(List.of(10.0, 11.0, 12.0), f.getForecasts());
+    }
+
+    @Test
+    public void getIntervalsReturnsAllValues() {
+        IntervalForecast f = new IntervalForecast(forecasts(), intervals());
+        assertEquals(3, f.getIntervals().size());
+    }
+
+    @Test
+    public void getForecastsReturnsDefensiveCopy() {
+        IntervalForecast f = new IntervalForecast(forecasts(), intervals());
+        f.getForecasts().add(99.0);
+        assertEquals(3, f.getForecasts().size());
+    }
+
+    @Test
+    public void getIntervalsReturnsDefensiveCopy() {
+        IntervalForecast f = new IntervalForecast(forecasts(), intervals());
+        f.getIntervals().clear();
+        assertEquals(3, f.getIntervals().size());
+    }
+
+    @Test
+    public void constructorIsDefensiveOverInputLists() {
+        List<Double> fc = forecasts();
+        IntervalForecast f = new IntervalForecast(fc, intervals());
+        fc.add(99.0);
+        assertEquals(3, f.getForecasts().size());
+    }
+
+    @Test
+    public void intervalHorizonAndBoundsAreCorrect() {
+        PredictionInterval pi = new PredictionInterval(1, 10.0, 8.0, 12.0, 0.95);
+        assertEquals(1, pi.getStep());
+        assertEquals(10.0, pi.getPointForecast(), 1e-15);
+        assertEquals(8.0,  pi.getLower(), 1e-15);
+        assertEquals(12.0, pi.getUpper(), 1e-15);
+        assertEquals(0.95, pi.getConfidenceLevel(), 1e-15);
+    }
+
+    @Test
+    public void predictionIntervalRejectsStepZero() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PredictionInterval(0, 10.0, 8.0, 12.0, 0.95));
+    }
+
+    @Test
+    public void predictionIntervalRejectsNegativeStep() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PredictionInterval(-1, 10.0, 8.0, 12.0, 0.95));
+    }
+
+    @Test
+    public void predictionIntervalRejectsConfidenceZero() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PredictionInterval(1, 10.0, 8.0, 12.0, 0.0));
+    }
+
+    @Test
+    public void predictionIntervalRejectsConfidenceOne() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PredictionInterval(1, 10.0, 8.0, 12.0, 1.0));
+    }
+}

--- a/src/test/java/tslib/evaluation/TrainTestSplitTest.java
+++ b/src/test/java/tslib/evaluation/TrainTestSplitTest.java
@@ -1,0 +1,94 @@
+package tslib.evaluation;
+
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TrainTestSplitTest {
+
+    private static final List<Double> SERIES = List.of(1.0, 2.0, 3.0, 4.0, 5.0);
+
+    @Test
+    public void atIndexSplitsCorrectly() {
+        TrainTestSplit split = TrainTestSplit.atIndex(SERIES, 3);
+        assertEquals(List.of(1.0, 2.0, 3.0), split.getTrain());
+        assertEquals(List.of(4.0, 5.0), split.getTest());
+    }
+
+    @Test
+    public void atIndexMinimalSplit() {
+        TrainTestSplit split = TrainTestSplit.atIndex(SERIES, 1);
+        assertEquals(1, split.getTrain().size());
+        assertEquals(4, split.getTest().size());
+    }
+
+    @Test
+    public void atIndexMaximalSplit() {
+        TrainTestSplit split = TrainTestSplit.atIndex(SERIES, 4);
+        assertEquals(4, split.getTrain().size());
+        assertEquals(1, split.getTest().size());
+    }
+
+    @Test
+    public void getTrainReturnsDefensiveCopy() {
+        TrainTestSplit split = TrainTestSplit.atIndex(SERIES, 3);
+        List<Double> train = split.getTrain();
+        train.add(99.0);
+        assertEquals(3, split.getTrain().size());
+    }
+
+    @Test
+    public void getTestReturnsDefensiveCopy() {
+        TrainTestSplit split = TrainTestSplit.atIndex(SERIES, 3);
+        List<Double> test = split.getTest();
+        test.add(99.0);
+        assertEquals(2, split.getTest().size());
+    }
+
+    @Test
+    public void ratioSplitsCorrectly() {
+        List<Double> series = List.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0);
+        TrainTestSplit split = TrainTestSplit.ratio(series, 0.8);
+        assertEquals(8, split.getTrain().size());
+        assertEquals(2, split.getTest().size());
+    }
+
+    @Test
+    public void ratioRoundsToNearestValidSize() {
+        List<Double> series = List.of(1.0, 2.0, 3.0);
+        TrainTestSplit split = TrainTestSplit.ratio(series, 0.6);
+        assertEquals(3, split.getTrain().size() + split.getTest().size());
+        assertTrue(split.getTrain().size() >= 1);
+        assertTrue(split.getTest().size() >= 1);
+    }
+
+    @Test
+    public void atIndexRejectsNull() {
+        assertThrows(IllegalArgumentException.class, () -> TrainTestSplit.atIndex(null, 1));
+    }
+
+    @Test
+    public void atIndexRejectsSingleElementList() {
+        assertThrows(IllegalArgumentException.class, () -> TrainTestSplit.atIndex(List.of(1.0), 0));
+    }
+
+    @Test
+    public void atIndexRejectsTrainSizeZero() {
+        assertThrows(IllegalArgumentException.class, () -> TrainTestSplit.atIndex(SERIES, 0));
+    }
+
+    @Test
+    public void atIndexRejectsTrainSizeEqualToDataSize() {
+        assertThrows(IllegalArgumentException.class, () -> TrainTestSplit.atIndex(SERIES, SERIES.size()));
+    }
+
+    @Test
+    public void ratioRejectsZero() {
+        assertThrows(IllegalArgumentException.class, () -> TrainTestSplit.ratio(SERIES, 0.0));
+    }
+
+    @Test
+    public void ratioRejectsOne() {
+        assertThrows(IllegalArgumentException.class, () -> TrainTestSplit.ratio(SERIES, 1.0));
+    }
+}

--- a/src/test/java/tslib/math/ProbabilityTest.java
+++ b/src/test/java/tslib/math/ProbabilityTest.java
@@ -1,0 +1,83 @@
+package tslib.math;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProbabilityTest {
+
+    @Test
+    public void normalCdfAtZeroIsHalf() {
+        assertEquals(0.5, Probability.normalCdf(0.0), 1e-6);
+    }
+
+    @Test
+    public void normalCdfKnownQuantiles() {
+        assertEquals(0.975, Probability.normalCdf(1.96), 1e-3);
+        assertEquals(0.025, Probability.normalCdf(-1.96), 1e-3);
+        assertEquals(0.841, Probability.normalCdf(1.0), 1e-3);
+    }
+
+    @Test
+    public void normalCdfSymmetry() {
+        double[] xs = {0.5, 1.0, 1.645, 2.0, 2.576};
+        for (double x : xs) {
+            assertEquals(1.0, Probability.normalCdf(x) + Probability.normalCdf(-x), 1e-9,
+                    "symmetry violated at x=" + x);
+        }
+    }
+
+    @Test
+    public void inverseNormalCdfAtHalf() {
+        assertEquals(0.0, Probability.inverseNormalCdf(0.5), 1e-6);
+    }
+
+    @Test
+    public void inverseNormalCdfKnownQuantiles() {
+        assertEquals(1.96, Probability.inverseNormalCdf(0.975), 1e-2);
+        assertEquals(-1.96, Probability.inverseNormalCdf(0.025), 1e-2);
+        assertEquals(2.576, Probability.inverseNormalCdf(0.995), 1e-2);
+    }
+
+    @Test
+    public void inverseNormalCdfLowerTailBranch() {
+        double p = 0.005;
+        double z = Probability.inverseNormalCdf(p);
+        assertTrue(z < -2.5, "lower tail z should be < -2.5 for p=0.005");
+    }
+
+    @Test
+    public void inverseNormalCdfUpperTailBranch() {
+        double p = 0.995;
+        double z = Probability.inverseNormalCdf(p);
+        assertTrue(z > 2.5, "upper tail z should be > 2.5 for p=0.995");
+    }
+
+    @Test
+    public void roundTrip() {
+        double[] probs = {0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99};
+        for (double p : probs) {
+            assertEquals(p, Probability.normalCdf(Probability.inverseNormalCdf(p)), 1e-6,
+                    "round-trip failed at p=" + p);
+        }
+    }
+
+    @Test
+    public void inverseNormalCdfRejectsZero() {
+        assertThrows(IllegalArgumentException.class, () -> Probability.inverseNormalCdf(0.0));
+    }
+
+    @Test
+    public void inverseNormalCdfRejectsOne() {
+        assertThrows(IllegalArgumentException.class, () -> Probability.inverseNormalCdf(1.0));
+    }
+
+    @Test
+    public void inverseNormalCdfRejectsNegative() {
+        assertThrows(IllegalArgumentException.class, () -> Probability.inverseNormalCdf(-0.1));
+    }
+
+    @Test
+    public void inverseNormalCdfRejectsGreaterThanOne() {
+        assertThrows(IllegalArgumentException.class, () -> Probability.inverseNormalCdf(1.5));
+    }
+}

--- a/src/test/java/tslib/model/ExpSmoothingStatefulTest.java
+++ b/src/test/java/tslib/model/ExpSmoothingStatefulTest.java
@@ -1,0 +1,175 @@
+package tslib.model;
+
+import org.junit.jupiter.api.Test;
+import tslib.evaluation.IntervalForecast;
+import tslib.model.expsmoothing.DoubleExpSmoothing;
+import tslib.model.expsmoothing.SingleExpSmoothing;
+import tslib.model.expsmoothing.TripleExpSmoothing;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExpSmoothingStatefulTest {
+
+    private static final List<Double> NIST = Arrays.asList(
+            362.0, 385.0, 432.0, 341.0, 382.0, 409.0, 498.0, 387.0, 473.0, 513.0,
+            582.0, 474.0, 544.0, 582.0, 681.0, 557.0, 628.0, 707.0, 773.0, 592.0,
+            627.0, 725.0, 854.0, 661.0);
+
+    // ── SingleExpSmoothing ────────────────────────────────────────────────────
+
+    @Test
+    public void sesStatefulForecastMatchesStatelessFuturePortion() {
+        SingleExpSmoothing model = new SingleExpSmoothing(0.5);
+        int steps = 4;
+        List<Double> stateless = model.forecast(NIST, steps);
+        List<Double> stateful = model.fit(NIST).forecast(steps);
+        for (int i = 0; i < steps; i++) {
+            assertEquals(stateless.get(NIST.size() + i), stateful.get(i), 1e-9,
+                    "step " + (i + 1) + " mismatch");
+        }
+    }
+
+    @Test
+    public void sesStatefulForecastIsConstant() {
+        List<Double> fc = new SingleExpSmoothing(0.5).fit(NIST).forecast(5);
+        assertEquals(5, fc.size());
+        for (int i = 1; i < fc.size(); i++) {
+            assertEquals(fc.get(0), fc.get(i), 1e-12, "SES forecast should be flat");
+        }
+    }
+
+    @Test
+    public void sesStatefulForecastReturnsCorrectLength() {
+        assertEquals(6, new SingleExpSmoothing(0.3).fit(NIST).forecast(6).size());
+    }
+
+    @Test
+    public void sesIntervalsForecastCountMatchesSteps() {
+        IntervalForecast iv = new SingleExpSmoothing(0.5).fit(NIST).forecastWithIntervals(4, 0.95);
+        assertEquals(4, iv.getForecasts().size());
+        assertEquals(4, iv.getIntervals().size());
+    }
+
+    @Test
+    public void sesIntervalsWideningWithHorizon() {
+        IntervalForecast iv = new SingleExpSmoothing(0.5).fit(NIST).forecastWithIntervals(4, 0.95);
+        double first = iv.getIntervals().get(0).getUpper() - iv.getIntervals().get(0).getLower();
+        double last = iv.getIntervals().get(3).getUpper() - iv.getIntervals().get(3).getLower();
+        assertTrue(last > first, "intervals should widen with horizon");
+    }
+
+    @Test
+    public void sesThrowsIfForecastCalledBeforeFit() {
+        assertThrows(IllegalStateException.class, () -> new SingleExpSmoothing(0.5).forecast(4));
+    }
+
+    @Test
+    public void sesThrowsIfIntervalsCalledBeforeFit() {
+        assertThrows(IllegalStateException.class,
+                () -> new SingleExpSmoothing(0.5).forecastWithIntervals(4, 0.95));
+    }
+
+    // ── DoubleExpSmoothing ────────────────────────────────────────────────────
+
+    @Test
+    public void desStatefulForecastMatchesStatelessFuturePortion() {
+        DoubleExpSmoothing model = new DoubleExpSmoothing(0.5, 0.6, 0);
+        int steps = 4;
+        List<Double> stateless = model.forecast(NIST, steps);
+        List<Double> stateful = model.fit(NIST).forecast(steps);
+        for (int i = 0; i < steps; i++) {
+            assertEquals(stateless.get(NIST.size() + i), stateful.get(i), 1e-9,
+                    "step " + (i + 1) + " mismatch");
+        }
+    }
+
+    @Test
+    public void desStatefulForecastFollowsTrend() {
+        List<Double> fc = new DoubleExpSmoothing(0.5, 0.6, 0).fit(NIST).forecast(4);
+        assertEquals(4, fc.size());
+        for (double v : fc) assertTrue(v > 0, "forecast should be positive");
+    }
+
+    @Test
+    public void desIntervalsWidenWithHorizon() {
+        IntervalForecast iv = new DoubleExpSmoothing(0.5, 0.6, 0).fit(NIST).forecastWithIntervals(4, 0.95);
+        assertEquals(4, iv.getIntervals().size());
+        double first = iv.getIntervals().get(0).getUpper() - iv.getIntervals().get(0).getLower();
+        double last = iv.getIntervals().get(3).getUpper() - iv.getIntervals().get(3).getLower();
+        assertTrue(last > first, "intervals should widen with horizon");
+    }
+
+    @Test
+    public void desThrowsIfForecastCalledBeforeFit() {
+        assertThrows(IllegalStateException.class, () -> new DoubleExpSmoothing(0.5, 0.5, 0).forecast(4));
+    }
+
+    // ── TripleExpSmoothing ────────────────────────────────────────────────────
+
+    @Test
+    public void tesCleanConstructorWorks() {
+        // should not require debug flag
+        assertDoesNotThrow(() -> new TripleExpSmoothing(0.5, 0.4, 0.6, 4).fit(NIST).forecast(4));
+    }
+
+    @Test
+    public void tesStatefulForecastReturnsCorrectLength() {
+        List<Double> fc = new TripleExpSmoothing(0.5, 0.4, 0.6, 4).fit(NIST).forecast(8);
+        assertEquals(8, fc.size());
+    }
+
+    @Test
+    public void tesStatefulForecastValuesArePositive() {
+        List<Double> fc = new TripleExpSmoothing(0.5, 0.4, 0.6, 4).fit(NIST).forecast(4);
+        for (double v : fc) assertTrue(v > 0, "forecast values should be positive");
+    }
+
+    @Test
+    public void tesSeasonalPatternRepeatsAfterOnePeriod() {
+        TripleExpSmoothing model = new TripleExpSmoothing(0.5, 0.4, 0.6, 4).fit(NIST);
+        List<Double> fc = model.forecast(8);
+        // Same season at h=1 and h=5 should have same seasonal factor applied
+        // (exact values differ by trend, but ratio is approximately the same)
+        double ratio1 = fc.get(0) / fc.get(4);
+        double ratio2 = fc.get(1) / fc.get(5);
+        // Both ratios should be close to 1 (trend-adjusted), not wildly different
+        assertTrue(ratio1 > 0.5 && ratio1 < 2.0, "seasonal cycling should be coherent h=1 vs h=5");
+        assertTrue(ratio2 > 0.5 && ratio2 < 2.0, "seasonal cycling should be coherent h=2 vs h=6");
+    }
+
+    @Test
+    public void tesIntervalsReturnCorrectCount() {
+        IntervalForecast iv = new TripleExpSmoothing(0.5, 0.4, 0.6, 4).fit(NIST)
+                .forecastWithIntervals(4, 0.95);
+        assertEquals(4, iv.getForecasts().size());
+        assertEquals(4, iv.getIntervals().size());
+    }
+
+    @Test
+    public void tesThrowsIfForecastCalledBeforeFit() {
+        assertThrows(IllegalStateException.class,
+                () -> new TripleExpSmoothing(0.5, 0.4, 0.6, 4).forecast(4));
+    }
+
+    @Test
+    public void tesThrowsIfDataTooShort() {
+        List<Double> short4 = Arrays.asList(1.0, 2.0, 3.0, 4.0);
+        assertThrows(IllegalArgumentException.class,
+                () -> new TripleExpSmoothing(0.5, 0.4, 0.6, 4).fit(short4));
+    }
+
+    // ── TimeSeriesModel interface ─────────────────────────────────────────────
+
+    @Test
+    public void allEtsModelsImplementTimeSeriesModel() {
+        tslib.model.TimeSeriesModel ses = new SingleExpSmoothing(0.5);
+        tslib.model.TimeSeriesModel des = new DoubleExpSmoothing(0.5, 0.5, 0);
+        tslib.model.TimeSeriesModel tes = new TripleExpSmoothing(0.5, 0.4, 0.6, 4);
+        assertNotNull(ses.fit(NIST).forecast(2));
+        assertNotNull(des.fit(NIST).forecast(2));
+        assertNotNull(tes.fit(NIST).forecast(2));
+    }
+}

--- a/src/test/java/tslib/tests/RidgeRegressionTest.java
+++ b/src/test/java/tslib/tests/RidgeRegressionTest.java
@@ -1,0 +1,87 @@
+package tslib.tests;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RidgeRegressionTest {
+
+    private static double[][] column(double... xs) {
+        double[][] X = new double[xs.length][1];
+        for (int i = 0; i < xs.length; i++) X[i][0] = xs[i];
+        return X;
+    }
+
+    @Test
+    public void defaultL2penaltyIsZero() {
+        RidgeRegression r = new RidgeRegression(column(1, 2, 3), new double[]{2, 4, 6});
+        assertEquals(0.0, r.getL2penalty(), 1e-15);
+    }
+
+    @Test
+    public void smallPenaltyApproximatesOls() {
+        double[][] X = column(1, 2, 3, 4, 5);
+        double[] Y = {2, 4, 6, 8, 10};
+        RidgeRegression r = new RidgeRegression(X, Y);
+        r.updateCoefficients(1e-10);
+        assertEquals(2.0, r.getCoefficients()[0], 1e-4);
+    }
+
+    @Test
+    public void largerPenaltyShrinksCoefficientsByKnownAmount() {
+        // Y = 2*X, so OLS β=2; with λ=||X||²=55, ridge β=110/(55+55)=1.0
+        double[][] X = column(1, 2, 3, 4, 5);
+        double[] Y = {2, 4, 6, 8, 10};
+        RidgeRegression r = new RidgeRegression(X, Y);
+        r.updateCoefficients(55.0);
+        assertEquals(1.0, r.getCoefficients()[0], 1e-9);
+    }
+
+    @Test
+    public void shrinkageIsMonotoneInPenalty() {
+        double[][] X = column(1, 2, 3, 4, 5);
+        double[] Y = {2, 4, 6, 8, 10};
+        RidgeRegression r = new RidgeRegression(X, Y);
+        r.updateCoefficients(1.0);
+        double betaSmall = r.getCoefficients()[0];
+        r.updateCoefficients(100.0);
+        double betaLarge = r.getCoefficients()[0];
+        assertTrue(betaLarge < betaSmall, "larger penalty should produce smaller coefficient");
+    }
+
+    @Test
+    public void standardErrorsArePositiveWithNoisyData() {
+        double[][] X = column(1, 2, 3, 4, 5);
+        double[] Y = {2.1, 3.9, 6.2, 7.8, 10.1};
+        RidgeRegression r = new RidgeRegression(X, Y);
+        r.updateCoefficients(0.01);
+        double[] se = r.getStandarderrors();
+        assertNotNull(se);
+        assertEquals(1, se.length);
+        assertTrue(se[0] > 0.0, "standard error should be positive with noisy data");
+    }
+
+    @Test
+    public void getL2penaltyReflectsLastUpdateCoefficients() {
+        double[][] X = column(1, 2, 3);
+        double[] Y = {1, 2, 3};
+        RidgeRegression r = new RidgeRegression(X, Y);
+        r.updateCoefficients(42.0);
+        assertEquals(42.0, r.getL2penalty(), 1e-15);
+    }
+
+    @Test
+    public void setL2penaltyUpdatesValue() {
+        RidgeRegression r = new RidgeRegression(column(1, 2, 3), new double[]{1, 2, 3});
+        r.setL2penalty(7.5);
+        assertEquals(7.5, r.getL2penalty(), 1e-15);
+    }
+
+    @Test
+    public void coefficientsLengthMatchesFeatureCount() {
+        double[][] X = new double[][]{{1, 0}, {0, 1}, {1, 1}, {2, 1}};
+        double[] Y = {1, 2, 3, 4};
+        RidgeRegression r = new RidgeRegression(X, Y);
+        r.updateCoefficients(0.1);
+        assertEquals(2, r.getCoefficients().length);
+    }
+}


### PR DESCRIPTION
  New interface: tslib.model.TimeSeriesModel:  A common contract all univariate models now implement: fit(data) → forecast(steps) → forecastWithIntervals(steps, confidenceLevel). The REST layer can treat every model uniformly through this interface.

  All 3 ExponentialSmoothing classes now have a stateful API:
  - fit(List<Double>) captures model state (last smoothed value / level+trend / level+trend+seasonal indices)
  - forecast(int steps) returns only future values (no more stripping the history off a combined array)
  - forecastWithIntervals(int steps, double confidenceLevel) returns residual-based prediction intervals
  - Old forecast(List<Double>, int) kept intact — existing call sites unchanged

  TripleExpSmoothing clean constructor: (alpha, beta, gamma, period) — no debug flag in the public API.

  AutoArima and AutoETS: both now implement TimeSeriesModel and expose forecastWithIntervals. AutoETS internally uses
  the stateful ETS API after selection, so it no longer has to slice off the history on every call.

  Interface coverage: implements TimeSeriesModel
  ARIMA, SARIMA, LocalLevelModel, AutoArima, AutoETS, SingleExpSmoothing, DoubleExpSmoothing, TripleExpSmoothing —
  everything the REST API will serve.

  The library is now in a consistent, stable state for a REST API layer.