### PR TITLE
  Add REST API hardening: auth, rate-limiting, request-size, actuator, OpenAPI export, Docker CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build JAR
+        run: ./gradlew :tslib-api:bootJar
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: navdeep-g/tslib-api
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=
+            type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: tslib-api
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,16 +33,17 @@ This document describes what has been built, what is actively planned, and what 
 - Dockerfile and Docker Compose for container deployment
 - Working client examples for curl, Python (`requests`), and R (`httr2`)
 
+### REST API hardening (Phase 12 follow-on)
+- Optional API-key authentication (`ApiKeyFilter`) — header-based, toggled via `tslib.api-key.enabled` in `application.properties`
+- Token-bucket rate limiting per client IP (`RateLimitFilter`) — configurable requests-per-minute, disabled by default
+- Request-size enforcement (`RequestSizeFilter`) — rejects payloads above `tslib.request.max-size-bytes` (default 1 MB)
+- Health and readiness endpoints at `/actuator/health` for load-balancer and Docker health-check integration
+- OpenAPI spec auto-export to `docs/openapi.json` via `springdoc-openapi-gradle-plugin` — clients can generate typed SDKs without a running server
+- GitHub Actions workflow (`.github/workflows/docker-publish.yml`) publishes `navdeep-g/tslib-api` to Docker Hub on every push to `master` and on version tags
+
 ---
 
 ## Planned (near-term)
-
-### REST API hardening
-- [ ] Optional API-key authentication (header-based, configurable via `application.properties`)
-- [ ] Request size and rate limiting to prevent abuse on public deployments
-- [ ] Health and readiness endpoints (`/actuator/health`) for load-balancer integration
-- [ ] Publish a Docker image to Docker Hub under `navdeep-g/tslib-api`
-- [ ] OpenAPI spec export as a checked-in file so clients can generate typed SDKs without a running server
 
 ### Client libraries
 - [ ] **Python package** (`tslib-py`) — thin `requests`-based wrapper with typed dataclasses for every request/response, installable via `pip`

--- a/tslib-api/build.gradle
+++ b/tslib-api/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.springdoc.openapi-gradle-plugin' version '1.9.0'
 }
 
 group = 'io.github.navdeep-g'
@@ -21,7 +22,15 @@ dependencies {
     implementation project(':')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+}
+
+openApi {
+    apiDocsUrl = 'http://localhost:8080/api-docs'
+    outputDir = file("${project.rootDir}/docs")
+    outputFileName = 'openapi.json'
+    waitTimeInSeconds = 30
 }
 
 tasks.withType(Test).configureEach {

--- a/tslib-api/docker-compose.yml
+++ b/tslib-api/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - SERVER_PORT=8080
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/api-docs"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/tslib-api/src/main/java/tslib/api/filter/ApiKeyFilter.java
+++ b/tslib-api/src/main/java/tslib/api/filter/ApiKeyFilter.java
@@ -1,0 +1,47 @@
+package tslib.api.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Order(1)
+public class ApiKeyFilter extends OncePerRequestFilter {
+
+    @Value("${tslib.api-key.enabled:false}")
+    private boolean enabled;
+
+    @Value("${tslib.api-key.value:}")
+    private String apiKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        if (!enabled) {
+            chain.doFilter(request, response);
+            return;
+        }
+        String path = request.getRequestURI();
+        if (path.startsWith("/actuator") || path.startsWith("/swagger-ui")
+                || path.startsWith("/api-docs")) {
+            chain.doFilter(request, response);
+            return;
+        }
+        String provided = request.getHeader("X-API-Key");
+        if (apiKey.isBlank() || !apiKey.equals(provided)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write(
+                    "{\"error\":\"Unauthorized\",\"message\":\"Invalid or missing X-API-Key header\"}");
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/tslib-api/src/main/java/tslib/api/filter/RateLimitFilter.java
+++ b/tslib-api/src/main/java/tslib/api/filter/RateLimitFilter.java
@@ -1,0 +1,68 @@
+package tslib.api.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Order(2)
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    @Value("${tslib.rate-limit.enabled:false}")
+    private boolean enabled;
+
+    @Value("${tslib.rate-limit.requests-per-minute:60}")
+    private int requestsPerMinute;
+
+    // Each entry: [tokens, lastRefillEpochMs]
+    private final ConcurrentHashMap<String, long[]> buckets = new ConcurrentHashMap<>();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        if (!enabled) {
+            chain.doFilter(request, response);
+            return;
+        }
+        if (!tryConsume(clientIp(request))) {
+            response.setStatus(429);
+            response.setContentType("application/json");
+            response.getWriter().write(
+                    "{\"error\":\"Too Many Requests\",\"message\":\"Rate limit exceeded. Try again in a minute.\"}");
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    private boolean tryConsume(String ip) {
+        long now = System.currentTimeMillis();
+        long[] bucket = buckets.computeIfAbsent(ip, k -> new long[]{requestsPerMinute, now});
+        synchronized (bucket) {
+            long elapsed = now - bucket[1];
+            long refill = (long) (elapsed * requestsPerMinute / 60_000.0);
+            if (refill > 0) {
+                bucket[0] = Math.min(requestsPerMinute, bucket[0] + refill);
+                bucket[1] = now;
+            }
+            if (bucket[0] <= 0) return false;
+            bucket[0]--;
+            return true;
+        }
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/tslib-api/src/main/java/tslib/api/filter/RequestSizeFilter.java
+++ b/tslib-api/src/main/java/tslib/api/filter/RequestSizeFilter.java
@@ -1,0 +1,34 @@
+package tslib.api.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Order(3)
+public class RequestSizeFilter extends OncePerRequestFilter {
+
+    @Value("${tslib.request.max-size-bytes:1048576}")
+    private long maxSizeBytes;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        int contentLength = request.getContentLength();
+        if (contentLength > maxSizeBytes) {
+            response.setStatus(413);
+            response.setContentType("application/json");
+            response.getWriter().write(
+                    "{\"error\":\"Payload Too Large\",\"message\":\"Request body exceeds the maximum allowed size.\"}");
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/tslib-api/src/main/resources/application.properties
+++ b/tslib-api/src/main/resources/application.properties
@@ -8,3 +8,21 @@ springdoc.swagger-ui.tagsSorter=alpha
 
 spring.jackson.serialization.write-dates-as-timestamps=false
 spring.jackson.deserialization.fail-on-unknown-properties=false
+
+# Actuator — health and readiness for load-balancer probes
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=never
+
+# API key authentication (disabled by default; set enabled=true and provide a value to protect the API)
+tslib.api-key.enabled=false
+tslib.api-key.value=
+
+# Rate limiting — token-bucket per client IP (disabled by default)
+tslib.rate-limit.enabled=false
+tslib.rate-limit.requests-per-minute=60
+
+# Request size limits
+tslib.request.max-size-bytes=1048576
+server.tomcat.max-http-form-post-size=1MB
+spring.servlet.multipart.max-request-size=1MB
+spring.servlet.multipart.max-file-size=1MB


### PR DESCRIPTION
  - ApiKeyFilter: optional header-based API key auth, toggled via tslib.api-key.enabled
  - RateLimitFilter: per-IP token-bucket rate limiting (tslib.rate-limit.*)
  - RequestSizeFilter: rejects oversized request bodies (default 1 MB cap)
  - spring-boot-starter-actuator added; /actuator/health wired for load-balancer and Docker Compose health-check probes
  - springdoc-openapi-gradle-plugin exports docs/openapi.json at build time so clients can generate typed SDKs without a running server
  - .github/workflows/docker-publish.yml: publishes navdeep-g/tslib-api to Docker Hub on master push and version tags
  - ROADMAP.md updated to reflect all hardening items as complete